### PR TITLE
fix: timed actions not working

### DIFF
--- a/classes/models/Command.php
+++ b/classes/models/Command.php
@@ -89,9 +89,9 @@ class Command
     $date_now = date('Y-m-d H:i:s');
 
     $count_datasets = 0; // number of datasets retrieved
-    $stmt = $this->db->query('SELECT * FROM ' . $this->db->au_commands . ' WHERE active = 1 AND date_start = :start_date');
+    $stmt = $this->db->query('SELECT * FROM ' . $this->db->au_commands . ' WHERE active = 1 AND date_start <= :date_now');
 
-    $this->db->bind(':start_date', $date_now); // bind date
+    $this->db->bind(':date_now', $date_now); // bind date
 
     $err = false;
     try {


### PR DESCRIPTION
Fixes https://github.com/aula-app/aula-frontend/issues/584 by including commands that are due by the moment of execution.

Instead of comparing exact equality of the current datetime and due time of command, to the resolution of a single second, comparison now happens with less-than-or-equal operator which captures any due commands even from previous days, or if the `getDueCommands()` is executed after `00:00:00` on that day. 