### PR TITLE
fix set_password on user creation

### DIFF
--- a/controllers/set_password.php
+++ b/controllers/set_password.php
@@ -8,14 +8,26 @@ require_once ($baseHelperDir.'JWT.php');
 require_once(__DIR__ . '/../config/instances_config.php');
 
 $headers = apache_request_headers();
-$db = new Database($headers['aula-instance-code']);
-$code = $headers['aula-instance-code'];
+
+if (array_key_exists('aula-instance-code', $headers)) {
+  $code = $headers['aula-instance-code'];
+} else {
+  if (array_key_exists('code', $_GET)) {
+    $code = $_GET['code'];
+  } else {
+    echo json_encode(["success" => false, "message" => "Fail to get instance code."]);
+    return;
+  }
+}
+
+$db = new Database($code);
 $crypt = new Crypt($cryptFile);
 $syslog = new Systemlog ($db);
 $jwt = new JWT($instances[$code]['jwt_key'], $db, $crypt, $syslog);
 
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {
   $secret =  $_GET["secret"];
+
   $stmt = $db->query('SELECT user_id FROM au_change_password WHERE secret = :secret');
   $db->bind(':secret', $secret); 
   


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

<!-- Example:
After the last update it became apparent that we did fetch the new results, but didn't actually store them properly. This caused a glitch in the UI whenever the user would refresh the page.
-->

## Checklist

- [ ] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [ ] Backward and forward compatible with FE <!-- If not, please describe in detail and include other PR links -->
- [ ] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
