### PR TITLE
fix: upload - when instance folder doesn't exist, create it

### DIFF
--- a/classes/models/Media.php
+++ b/classes/models/Media.php
@@ -309,6 +309,7 @@ class Media
     $status = intval($status);
     $type = intval($type);
     $system_type = intval($system_type);
+    $result = [];
 
     // if it is an avatar
     if ($system_type == 0) {
@@ -316,15 +317,15 @@ class Media
       $this->db->bind(':updater_id', $updater_id); // id of the user doing the update (i.e. admin)
 
       try {
-        $action = $this->db->execute(); // do the query
-        $has_avatar = count($this->db->resultSet()) > 0;
-        $old_avatar = $this->db->resultSet()[0];
+        $result = $this->db->resultSet(); // do the query
+        $has_avatar = !empty($result);
       } catch (Exception $e) {
         $err = true;
       }
     }
 
     if ($has_avatar) {
+      $old_avatar = $result[0];
       unlink($this->files_dir . '/' . $old_avatar["filename"]);
       $stmt = $this->db->query('DELETE FROM ' . $this->db->au_media . ' WHERE updater_id = :updater_id');
       $this->db->bind(':updater_id', $updater_id); // id of the user doing the update (i.e. admin)

--- a/controllers/upload.php
+++ b/controllers/upload.php
@@ -14,11 +14,11 @@ if (!isset($matches[0])) {
   throw new RuntimeException('Invalid instance code');
 }
 
-$db = new Database($headers['aula-instance-code']);
+$db = new Database($code);
 $crypt = new Crypt($cryptFile);
 $syslog = new Systemlog($db);
 $jwt = new JWT($instances[$code]['jwt_key'], $db, $crypt, $syslog);
-$media = new Media($db, $crypt, $syslog, $filesDir);
+$media = new Media($db, $crypt, $syslog, $filesDir . '/' . $code);
 
 $check_jwt = $jwt->check_jwt();
 

--- a/controllers/upload.php
+++ b/controllers/upload.php
@@ -74,6 +74,10 @@ if ($check_jwt) {
       throw new RuntimeException('Invalid file format.');
     }
 
+    if (!file_exists($filesDir . '/' . $code)) {
+      mkdir($filesDir . '/' . $code);
+    }
+
     $random_part = bin2hex(random_bytes(8)) . number_format(microtime(true), 0, '', '');
     $file_name = sha1_file($_FILES['file']['tmp_name']) . $random_part . "." . $ext;
     $file_path = sprintf($filesDir . '/' . $code . '/%s', $file_name);


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Upload fails if instance code folder doesn't exist in `files/` folder.

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [-] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [-] Changelist updated
- [x] Backward and forward compatible with FE <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
