### PR TITLE
ref: make the email templates use the same subst logic

### DIFF
--- a/controllers/forgot_password.php
+++ b/controllers/forgot_password.php
@@ -58,8 +58,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     	'MIME-Version' => $mime,
     	'Content-type' => $content);
     
+    // @TODO: remove the sprintf call after the next deployment, it will be noop once the template is updated
     $email_body = sprintf($email_forgot_password_body, $realname, $secret, $secret);
     $email_body = str_replace("<CODE>", $code, $email_body);
+    $email_body = str_replace("<NAME>", $realname, $email_body);
+    $email_body = str_replace("<SECRET_KEY>", $secret, $email_body);
 
     $mail = $smtp->send($email, $headers, $email_body);
 


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

We have two different ways of dealing with templating emails - Users->addUser and forgot_password.php. This PR enables the usage of "named parameters" in the forgot_password email template.

## Checklist

- [ ] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with FE <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
