### PR TITLE
fix(security): don't leak PDOException on query execution

### DIFF
--- a/src/classes/models/Database.php
+++ b/src/classes/models/Database.php
@@ -68,7 +68,7 @@
             $this->dbh = new PDO($dsn, $this->user, $this->pass, $options);
         } catch(PDOException $e) {
             $this->error = $e->getMessage();
-            error_log("ERROR occured: ".$e->getMessage());
+            error_log("ERROR occurred: ".$e->getMessage());
         }
         
     }


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

got this on staging:
```
PDOException Object
(
    [message:protected] => SQLSTATE[42S02]: Base table or view not found: 1146 Table 'REDACTED' doesn't exist
    [string:Exception:private] => 
    [code:protected] => 42S02
    [file:protected] => /var/www/html/api/classes/models/Database.php
    [line:protected] => 112
    [trace:Exception:private] => Array
...
...
```

## Checklist

- [ ] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with FE <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
