### PR TITLE
fix(email): Reply-To use support@aula.de

### DIFF
--- a/src/classes/models/User.php
+++ b/src/classes/models/User.php
@@ -2259,12 +2259,7 @@ class User
         $content = "text/html; charset=utf-8";
         $mime = "1.0";
 
-        global $email_host;
-        global $email_port;
-        global $email_username;
-        global $email_password;
         global $email_from;
-        global $email_address;
         global $email_creation_subject;
         global $email_creation_body;
 
@@ -2272,7 +2267,7 @@ class User
           'From' => $email_from,
           'To' => $email,
           'Subject' => $email_creation_subject,
-          'Reply-To' => $email_address,
+          'Reply-To' => $email_address_support,
           'MIME-Version' => $mime,
           'Content-type' => $content
         );

--- a/src/controllers/forgot_password.php
+++ b/src/controllers/forgot_password.php
@@ -55,7 +55,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $headers = array ('From' => $email_from,
     	'To' => $email,
     	'Subject' => 	$email_forgot_password_subject,
-    	'Reply-To' => $email_address,
+    	'Reply-To' => $email_address_support,
     	'MIME-Version' => $mime,
     	'Content-type' => $content);
     


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Uses `support [at] aula.de` as support email instead of `admin@neu.aula.de` because that one doesn't have an inbox. See also: https://github.com/aula-app/infra/commit/da7fb9d775ee50ff3b262fc848ca7b2373de8652

## Checklist

- [ ] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with FE <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
