### PR TITLE
fix: scheduled commands

### DIFF
--- a/src/classes/helpers/Permissions.php
+++ b/src/classes/helpers/Permissions.php
@@ -202,23 +202,7 @@ function checkPermissions($db, $crypt, $syslog, $model_name, $method, $arguments
         "open_roles" => ["admin", "tech_admin"]
       ],
 
-      "getCommandBaseData" => [
-        "open_roles" => ["admin", "tech_admin"]
-      ],
-
       "addCommand" => [
-        "open_roles" => ["admin", "tech_admin"]
-      ],
-
-      "setActiveStatus" => [
-        "open_roles" => ["admin", "tech_admin"]
-      ],
-
-      "setCommandStatus" => [
-        "open_roles" => ["admin", "tech_admin"]
-      ],
-
-      "setCommandDate" => [
         "open_roles" => ["admin", "tech_admin"]
       ],
     ],

--- a/src/classes/helpers/Permissions.php
+++ b/src/classes/helpers/Permissions.php
@@ -206,10 +206,6 @@ function checkPermissions($db, $crypt, $syslog, $model_name, $method, $arguments
         "open_roles" => ["admin", "tech_admin"]
       ],
 
-      "getDueCommands" => [
-        "open_roles" => ["admin", "tech_admin"]
-      ],
-
       "addCommand" => [
         "open_roles" => ["admin", "tech_admin"]
       ],

--- a/src/classes/models/Command.php
+++ b/src/classes/models/Command.php
@@ -302,21 +302,17 @@ class Command
     }
   }// end function
 
-  public function setCommandStatus($cmd_id, $status, $updater_id = 0)
+  public function setCommandStatus(int $id, int $status, $updater_id = 0)
   {
     /* edits a command, accepts the above parameters, all parameters are mandatory
      status = status of command (0=not exectued yet, 1=successfully executed, 2 = execution error)
      updater_id is the id of the user that does the update (i.E. admin )
     */
-    $cmd_id = intval($cmd_id); // checks id and converts id to db id if necessary (when hash id was passed)
-    $status = intval($status);
-    #
-    $stmt = $this->db->query('UPDATE ' . $this->db->au_commands . ' SET active= :status, last_update= NOW(), updater_id= :updater_id WHERE id= :command_id');
+    $stmt = $this->db->query('UPDATE ' . $this->db->au_commands . ' SET status= :status, last_update= NOW(), updater_id= :updater_id WHERE id= :command_id');
     // bind all VALUES
     $this->db->bind(':status', $status);
     $this->db->bind(':updater_id', $updater_id); // id of the user doing the update (i.e. admin)
-
-    $this->db->bind(':command_id', $cmd_id); // command that is updated
+    $this->db->bind(':command_id', $id); // command that is updated
 
     $err = false; // set error variable to false
     $count_datasets = 0; // init row count
@@ -325,12 +321,11 @@ class Command
       $action = $this->db->execute(); // do the query
 
     } catch (Exception $e) {
-
       $err = true;
     }
     if (!$err) {
       $count_datasets = intval($this->db->rowCount());
-      $this->syslog->addSystemEvent(0, "Command status changed for command " . $cmd_id . " to " . $status . " by " . $updater_id, 0, "", 1);
+      $this->syslog->addSystemEvent(0, "Command status changed for command " . $id . " to " . $status . " by " . $updater_id, 0, "", 1);
       $returnvalue['success'] = true; // set return value
       $returnvalue['error_code'] = 0; // error code
       $returnvalue['data'] = $count_datasets; // returned data

--- a/src/cron.php
+++ b/src/cron.php
@@ -1,151 +1,135 @@
 <?php
 
-require_once (__DIR__ . '/../config/base_config.php'); // load base config with paths to classes etc.
-require_once (__DIR__ . '/../config/instances_config.php.php'); // load base config with paths to classes etc.
+require_once(__DIR__ . '/../config/base_config.php'); // load base config with paths to classes etc.
+require_once(__DIR__ . '/../config/instances_config.php'); // load base config with paths to classes etc.
 global $instances;
 
 echo ("LOADING CONFIG\n");
-echo ("baseClassModelDir: ".$baseClassModelDir."\n");
+echo ("baseClassModelDir: " . $baseClassModelDir . "\n");
 
-require_once ($baseHelperDir.'Crypt.php');
+require_once($baseHelperDir . 'Crypt.php');
+require_once($baseHelperDir . 'ResponseBuilder.php');
 
-require ('functions.php'); // include Class autoloader (models)
+require('functions.php'); // include Class autoloader (models)
 
 foreach ($instances as $code => $instance) {
-  echo ("LOADING DB\n");
-  // Create a new Database object with the MySQL credentials
+  echo ("\n\nLOADING {$code}...\n");
   $db = new Database($code);
-  
-  echo ("LOADING CRYPT AND SYSLOG CLASS WITH CRYPTFILE ".$cryptFile."\n");
-  $crypt = new Crypt(); // path to $cryptFile is currently known from base_config.php -> will be changed later to be secure
-  $syslog = new Systemlog ($db); // systemlog
-  
-  echo ("LOADING COMMAND CLASS\n");
-  
-  $command_class = new Command($db, $crypt, $syslog); // load command class
-  
-  echo ("LOADING CONVERTERS CLASS\n");
-  $converters = new Converters($db); // load converters
-  
-  echo ("LOADING THE REST CLASS\n");
-  $idea_class = new Idea ($db, $crypt, $syslog); //, $syslog); // instanciate group model class
-  $room_class = new Room ($db, $crypt, $syslog); // instanciate room model class
-  #$user_class = new User ($db, $crypt, $syslog); // instanciate room model class
-  $topic_class = new Topic ($db, $crypt, $syslog); // instanciate topic model class
-  $settings_class = new Settings($db, $crypt, $syslog); // load settings class
-  
-  $now = $converters -> getNow();
-  $time_only = $converters -> getTimeOnlyNow ();
-  
-  echo ("\n\nWelcome to the cron job");
-  echo ("\nNOW: ".$now);
-  echo ("\nTIME ONLY: ".$time_only);
-  echo ("\n\nchecking for commands in table ".$db->au_commands. " ALSO CHECKING: ".$db->user." P:".$db->pass);
-  // check commands first
+  $crypt = new Crypt();
+  $syslog = new Systemlog($db);
+  $command_class = new Command($db, $crypt, $syslog);
+  $converters = new Converters($db);
+
+  $now = $converters->getNow();
+  $time_only = $converters->getTimeOnlyNow();
+
+  echo ("NOW: $now\n");
+  echo ("TIME ONLY: $time_only\n");
+  echo ("Getting due commands...\n");
   $commands = $command_class->getDueCommands();
-  
-  foreach ($commmands as $command) {
-      // iterate through due commands
-      print_r ($command);
-      $cmd_id = intval ($command ['cmd_id']);
-      $cmd_params = $command ['parameters'];
-      $cmd_status = $command ['status'];
-  
-      // check which command and execute
-      /* implementeed commands:
-      10 = set online mode
-      20 = delete user
-      40 = set user status (user_Id ; 0,1,2)
-      */
-      switch ($cmd_id) {
-  
-          case 10: 
-              // set online mode
-              try {
-                  $cmd_params = intval ($cmd_params);
-                  // check if param is valid and within boundaries so faulty values are not updated 
-                  if ($cmd_params > -1 && $cmd_params < 6) {
-                      $return = $settings_class -> setInstanceOnlineMode($status, 99);
-                      if ($return ['error_code'] == 0) {
-                          $command_class->setCommandStatus ($cmd_id, 1); // command executed successfully
-                      } else {
-                          $command_class->setCommandStatus ($cmd_id, 3); // command not executed successfully
-                      }
-                  } else {
-                      $command_class->setCommandStatus ($cmd_id, 3); // params out of range
-                  }
-              } catch (Exception $err) {
-                  // error occured
-                  $command_class->setCommandStatus ($cmd_id, 4); // misc error occurred
-              }
-              
-          break;
-          
-          case 20: 
-              // delete user
-              try {
-                  $cmd_params_elems = explode (";", $cmd_params);
-                  
-                  $delete_mode = $cmd_params_elems [0]; // 0 = delete user only 1 = delete user + associated data (danger!) 
-                  $user_id = $cmd_params_elems [1]; 
-  
-                  // check if param is valid and within boundaries so faulty values are not updated 
-                  if ($cmd_params > 0) {
-                      $return = $user -> deleteUser ($user_id, $delete_mode, 99);
-                      if ($return ['error_code'] == 0) {
-                          $command_class->setCommandStatus ($cmd_id, 1); // command executed successfully
-                      } else {
-                          $command_class->setCommandStatus ($cmd_id, 3); // command not executed successfully
-                      }
-                  } else {
-                      $command_class->setCommandStatus ($cmd_id, 3); // params out of range
-                  }
-              } catch (Exception $err) {
-                  // error occured
-                  $command_class->setCommandStatus ($cmd_id, 4); // misc error occurred
-              }
-          
-          break;
-          
-          case 40: 
-              try {
-                  // set user status
-                  $cmd_params_elems = explode (";", $cmd_params);
-                  
-                  $status = $cmd_params_elems [0]; // 0 = deactivate user only 1 = activate user 2 = suspend 
-                  $user_id = $cmd_params_elems [1]; 
-  
-                  // check if param is valid and within boundaries so faulty values are not updated 
-                  if ($cmd_params > 0) {
-  
-                      $return = $user -> setUserStatus($user_id, $status, $updater_id = 0);
-  
-                      if ($return ['error_code'] == 0) {
-                          $command_class->setCommandStatus ($cmd_id, 1); // command executed successfully
-                      } else {
-                          $command_class->setCommandStatus ($cmd_id, 3); // command not executed successfully
-                      }
-                  } else {
-                      $command_class->setCommandStatus ($cmd_id, 3); // params out of range
-                  }
-              } catch (Exception $err) {
-                  // error occured
-                  $command_class->setCommandStatus ($cmd_id, 4); // misc error occurred
-              }
-  
-          break;
-      }
-  }  
+  if ($commands === null || $commands['error_code'] != 0) {
+    continue;
+  }
+  echo ("Due commands: " . json_encode($commands['data']) . "\n");
+
+  foreach ($commands['data'] as $command) {
+    // iterate through due commands
+    echo ($command);
+    $cmd_id = intval($command['cmd_id']);
+    $cmd_params = $command['parameters'];
+    $cmd_status = $command['status'];
+
+    // check which command and execute
+    /* implementeed commands:
+        10 = set online mode
+        20 = delete user
+        40 = set user status (user_Id ; 0,1,2)
+        */
+    switch ($cmd_id) {
+      case 10:
+        // set online mode
+        try {
+          $settings_class = new Settings($db, $crypt, $syslog);
+          $cmd_params = intval($cmd_params);
+          // check if param is valid and within boundaries so faulty values are not updated
+          if ($cmd_params > -1 && $cmd_params < 6) {
+            $return = $settings_class->setInstanceOnlineMode($status, 99);
+            if ($return['error_code'] == 0) {
+              $command_class->setCommandStatus($cmd_id, 1); // command executed successfully
+            } else {
+              $command_class->setCommandStatus($cmd_id, 3); // command not executed successfully
+            }
+          } else {
+            $command_class->setCommandStatus($cmd_id, 3); // params out of range
+          }
+        } catch (Exception $err) {
+          // error occured
+          $command_class->setCommandStatus($cmd_id, 4); // misc error occurred
+        }
+        break;
+
+      case 20:
+        // delete user
+        try {
+          $cmd_params_elems = explode(";", $cmd_params);
+
+          $delete_mode = $cmd_params_elems[0]; // 0 = delete user only 1 = delete user + associated data (danger!)
+          $user_id = $cmd_params_elems[1];
+
+          // check if param is valid and within boundaries so faulty values are not updated
+          if ($cmd_params > 0) {
+            $return = $user->deleteUser($user_id, $delete_mode, 99);
+            if ($return['error_code'] == 0) {
+              $command_class->setCommandStatus($cmd_id, 1); // command executed successfully
+            } else {
+              $command_class->setCommandStatus($cmd_id, 3); // command not executed successfully
+            }
+          } else {
+            $command_class->setCommandStatus($cmd_id, 3); // params out of range
+          }
+        } catch (Exception $err) {
+          // error occured
+          $command_class->setCommandStatus($cmd_id, 4); // misc error occurred
+        }
+        break;
+
+      case 40:
+        try {
+          // set user status
+          $cmd_params_elems = explode(";", $cmd_params);
+
+          $status = $cmd_params_elems[0]; // 0 = deactivate user only 1 = activate user 2 = suspend
+          $user_id = $cmd_params_elems[1];
+
+          // check if param is valid and within boundaries so faulty values are not updated
+          if ($cmd_params > 0) {
+            $return = $user->setUserStatus($user_id, $status, $updater_id = 0);
+            if ($return['error_code'] == 0) {
+              $command_class->setCommandStatus($cmd_id, 1); // command executed successfully
+            } else {
+              $command_class->setCommandStatus($cmd_id, 3); // command not executed successfully
+            }
+          } else {
+            $command_class->setCommandStatus($cmd_id, 3); // params out of range
+          }
+        } catch (Exception $err) {
+          // error occured
+          $command_class->setCommandStatus($cmd_id, 4); // misc error occurred
+        }
+        break;
+
+    }
+  }
   // check phases due for switching
-  
+
   // check if a backup is necessary (daily)
   if ($time_only == "00:00") {
-      // execute dump every day at midnight
-      try {
-          echo ("<br>DUMP IS DUE NOW: ".$time_only);
+    // execute dump every day at midnight
+    try {
+      echo ("<br>DUMP IS DUE NOW: " . $time_only);
       //$converters-> createDBDump();
-      } catch (Exception $err) {
-          // error occured
-      }
+    } catch (Exception $err) {
+      // error occured
+    }
   }
 }


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

This PR cleans up half-implemented `cron.php`. It removes all scheduled commands implementations except the one setting instance online status. The implementation of that command is fixed.

## How the cron executes

Host machine runs cron and asks docker container to execute scheduled commands (for now):
```yaml
- name: Create cron entry for running aula-backend scheduled commands
  become: true
  ansible.builtin.cron:
    name: aula-backend cron every 5 minutes
    hour: "*"
    minute: "*/5"
    user: "{{ ansible_user }}"
    job: "cd /opt/aula && docker compose exec -ti aula-backend php cron.php"
```

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [ ] ~Backward and forward compatible with FE~  **FE compatibility broken, but it wasn't working properly (at all) in any case**
- [x] Doesn't need update in the database
- [ ] Must be deployed ASAP (HOTFIX)
