### PR TITLE
ref(cron): scheduled commands refactored to isolate behavior

### DIFF
--- a/src/classes/models/Command.php
+++ b/src/classes/models/Command.php
@@ -8,7 +8,9 @@ if ($allowed_include == 1) {
   exit;
 }
 
-
+require_once(__DIR__ . '/../../../config/base_config.php');
+global $baseHelperDir;
+require_once($baseHelperDir . 'ResponseBuilder.php');
 
 class Command
 {

--- a/src/classes/scheduler/CommandDispatcher.php
+++ b/src/classes/scheduler/CommandDispatcher.php
@@ -1,0 +1,34 @@
+<?php
+
+require_once(__DIR__ . '/../../../config/base_config.php');
+global $baseClassDir;
+foreach (glob($baseClassDir . "./usecases/commands/*.php") as $file) {
+  require_once $file;
+}
+
+class CommandDispatcher
+{
+  private $commandHandlers;
+
+  public function __construct($db, $crypt, $syslog)
+  {
+    $this->commandHandlers = [
+      InstanceOnlineModeHandler::createWith($db, $crypt, $syslog)
+    ];
+  }
+
+  public function dispatch(mixed $command)
+  {
+    $commandType = @$command['cmd_id'];
+    if ($commandType === null) {
+      throw new RuntimeException("Invalid Command object (there's no ['cmd_id']).");
+    }
+
+    $handler = @$this->commandHandlers[$commandType];
+    if ($handler === null) {
+      throw new RuntimeException("No Handler found for the Command type (cmd_id = {$commandType}).");
+    }
+
+    return $handler->executeSafe($command);
+  }
+}

--- a/src/classes/scheduler/CommandScheduler.php
+++ b/src/classes/scheduler/CommandScheduler.php
@@ -1,0 +1,66 @@
+<?php
+
+require_once(__DIR__ . '/../../../config/base_config.php');
+require_once(__DIR__ . '/../../../config/instances_config.php');
+require(__DIR__ . '/../../functions.php');
+require_once($baseHelperDir . 'Crypt.php');
+global $baseClassDir;
+require_once($baseClassDir . 'scheduler/CommandDispatcher.php');
+
+class CommandSchedulerForInstance
+{
+  private $commandModelForInstance;
+  private $commandDispatcherForInstance;
+
+  public function __construct(protected $code)
+  {
+    $db = new Database($code);
+    $crypt = new Crypt();
+    $syslog = new Systemlog($db);
+    $this->commandModelForInstance = new Command($db, $crypt, $syslog);
+    $this->commandDispatcherForInstance = new CommandDispatcher($db, $crypt, $syslog);
+  }
+
+  public function dispatchAllDueCommands()
+  {
+    $commands = $this->getDueCommands();
+
+    foreach ($commands as $command) {
+      try {
+        $this->commandDispatcherForInstance->dispatch($command);
+        echo ("[{$this->code}] Success dispatching command id={$command['id']}\n");
+      } catch (Exception $exc) {
+        error_log("[{$this->code}] ERROR Dispatching/Executing command ({$command['id']}): " . $exc->getMessage());
+      }
+    }
+  }
+
+  protected function getDueCommands()
+  {
+    echo ("[{$this->code}] Getting due commands...\n");
+    $dueCommandsResult = $this->commandModelForInstance->getDueCommands();
+    if ($dueCommandsResult === null || $dueCommandsResult['error_code'] != 0) {
+      error_log("[{$this->code}] ERROR Due commands: " . json_encode($dueCommandsResult));
+      return;
+    }
+
+    $commands = $dueCommandsResult['data'];
+    echo ("[{$this->code}] Due commands: " . array_reduce($commands, function ($acc, $cmd) {
+      $acc .= "{'id':'{$cmd['id']}','cmd_id':'{$cmd['cmd_id']}'} ";
+      return $acc;
+    }, "") . "\n");
+    return $dueCommandsResult['data'];
+  }
+}
+
+class CommandScheduler
+{
+  public function dispatchDueCommands()
+  {
+    global $instances;
+    foreach ($instances as $code => $instance) {
+      $forInstance = new CommandSchedulerForInstance($code);
+      $forInstance->dispatchAllDueCommands();
+    }
+  }
+}

--- a/src/classes/usecases/README.md
+++ b/src/classes/usecases/README.md
@@ -1,0 +1,7 @@
+# UseCase
+
+## Architecture around UseCases
+
+Each UseCase is concerned by a single functionality, the separation of responsibilities is per class (per file). Each UseCase class orchestrates and binds together business rules across multiple Domains.
+
+UseCases — one class per user action (CreateIdea, CastVote, DelegateVote, AddComment, UpdateRole, ConfigureRoom, etc.). Orchestrates repositories, domain services, transactions, and side effects; not low-level persistence or pure domain logic.

--- a/src/classes/usecases/commands/CommandHandler.php
+++ b/src/classes/usecases/commands/CommandHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+abstract class CommandHandler
+{
+  private $commandModel;
+
+  private const COMMAND_STATUS_NOT_RUN = 0;
+  private const COMMAND_STATUS_SUCCESS = 1;
+  private const COMMAND_STATUS_EXECUTION_FAILURE = 2;
+  private const COMMAND_STATUS_VALIDATION_FAILED = 3;
+  private const COMMAND_STATUS_EXECUTION_EXCEPTION = 4;
+
+  public function __construct(protected $db, protected $crypt, protected $syslog)
+  {
+    $this->commandModel = new Command($db, $crypt, $syslog);
+  }
+
+  public function executeSafe(mixed $command)
+  {
+    if ($command === null || !is_array($command) || $command['id'] === null) {
+      throw new RuntimeException("Bad Command");
+    }
+
+    $id = $command['id'];
+    try {
+      $validationResult = $this->isValid($command);
+      if ($validationResult != true) {
+        $this->commandModel->setCommandStatus($id, self::COMMAND_STATUS_VALIDATION_FAILED);
+      }
+
+      // @TODO: nikola - use db transaction with SELECT .. FOR UPDATE for isolation
+
+      // @TODO: nikola - ensure no other handler is running the same command at the same time
+      //   (due to retries and long-running commands or multiple concurrent BE services)
+      $returnValue = $this->execute($command);
+
+      if ($returnValue['error_code'] == 0) {
+        $this->commandModel->setCommandStatus($id, self::COMMAND_STATUS_SUCCESS);
+        $this->commandModel->setActiveStatus($id, 0);
+      } else {
+        $this->commandModel->setCommandStatus($id, self::COMMAND_STATUS_EXECUTION_FAILURE);
+        $this->commandModel->setActiveStatus($id, 0);
+      }
+    } catch (Exception $err) {
+      error_log("Command execution ERROR " . $err->getMessage());
+      $this->commandModel->setCommandStatus($id, self::COMMAND_STATUS_EXECUTION_EXCEPTION);
+    }
+  }
+
+  abstract protected function isValid(mixed $command): bool;
+  abstract protected function execute(mixed $command): mixed;
+}

--- a/src/classes/usecases/commands/InstanceOnlineModeHandler.php
+++ b/src/classes/usecases/commands/InstanceOnlineModeHandler.php
@@ -1,0 +1,24 @@
+<?php
+
+class InstanceOnlineModeHandler extends CommandHandler
+{
+  protected Settings $settingsModel;
+
+  public static function createWith($db, $crypt, $syslog): InstanceOnlineModeHandler
+  {
+    $instance = new InstanceOnlineModeHandler($db, $crypt, $syslog);
+    $instance->settingsModel = new Settings($instance->db, $instance->crypt, $instance->syslog);
+    return $instance;
+  }
+
+  protected function execute($command): mixed
+  {
+    return $this->settingsModel->setInstanceOnlineMode(intval($command['parameters']), 99);
+  }
+
+  protected function isValid(mixed $command): bool
+  {
+    $newStatus = intval($command['parameters']);
+    return $newStatus >= 0 && $newStatus <= 5;
+  }
+}

--- a/src/classes/usecases/commands/README.md
+++ b/src/classes/usecases/commands/README.md
@@ -1,0 +1,12 @@
+# UseCase - Commands handling
+
+Each `Command` is handled by its own `CommandHandler` implementation, found in this folder.
+
+Each `CommandHandler` implementation needs to implement these two methods:
+
+```php
+abstract protected function isValid(mixed $command): bool;
+abstract protected function execute(mixed $command): mixed;
+```
+
+The Commands are supposed to be dispatched by the `CommandDispatcher` which orchestrates the `Command` to appropriate `CommandHandler` implementation based on the Command's `cmd_id` field.

--- a/src/cron.php
+++ b/src/cron.php
@@ -1,63 +1,7 @@
 <?php
 
-require_once(__DIR__ . '/../config/base_config.php'); // load base config with paths to classes etc.
-require_once(__DIR__ . '/../config/instances_config.php'); // load base config with paths to classes etc.
-global $instances;
+require_once(__DIR__ . '/../config/base_config.php');
+require_once($baseClassDir . './scheduler/CommandScheduler.php');
 
-echo ("LOADING CONFIG\n");
-echo ("baseClassModelDir: " . $baseClassModelDir . "\n");
-
-require_once($baseHelperDir . 'Crypt.php');
-require_once($baseHelperDir . 'ResponseBuilder.php');
-
-require('functions.php'); // include Class autoloader (models)
-
-foreach ($instances as $code => $instance) {
-  echo ("\n\nLOADING {$code}...\n");
-  $db = new Database($code);
-  $crypt = new Crypt();
-  $syslog = new Systemlog($db);
-  $command_class = new Command($db, $crypt, $syslog);
-  $converters = new Converters($db);
-
-  echo ("Getting due commands...\n");
-  $commands = $command_class->getDueCommands();
-  if ($commands === null || $commands['error_code'] != 0) {
-    echo ("ERROR Due commands: " . json_encode($commands));
-    continue;
-  }
-  echo ("Due commands: " . json_encode($commands['data']) . "\n");
-
-  foreach ($commands['data'] as $command) {
-    $id = $command['id'];
-    $cmd_id = intval($command['cmd_id']);
-    $cmd_params = $command['parameters'];
-    $cmd_status = $command['status'];
-
-    switch ($cmd_id) {
-      case 0:
-        // set online mode
-        try {
-          $settings_class = new Settings($db, $crypt, $syslog);
-          $cmd_params = intval($cmd_params);
-          // check if param is valid and within boundaries so faulty values are not updated
-          if ($cmd_params >= 0 && $cmd_params <= 5) {
-            echo ("Setting online mode to $cmd_params");
-            $return = $settings_class->setInstanceOnlineMode($cmd_params, 99);
-            if ($return['error_code'] == 0) {
-              $command_class->setCommandStatus($id, 1); // command executed successfully
-              $command_class->setActiveStatus($id, 0);
-            } else {
-              $command_class->setCommandStatus($id, 3); // command not executed successfully
-            }
-          } else {
-            $command_class->setCommandStatus($id, 3); // params out of range
-          }
-        } catch (Exception $err) {
-          // error occured
-          $command_class->setCommandStatus($id, 4); // misc error occurred
-        }
-        break;
-    }
-  }
-}
+$commandScheduler = new CommandScheduler();
+$commandScheduler->dispatchDueCommands();


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Changed the code architecture related to Scheduled Commands. Now the system behavior is split into these distinct sections:
* Each Command has its own CommandHandler implementation which executes ONLY that Command "type" (`cmd_id`)
* `cron.php` is just a helper script to instruct CommandScheduler to process all due Commands
* Fetching due Commands per each Instance is a job of CommandScheduler
* CommandDispatcher dispatches Commands for execution to their respective CommandHandler implementation (based on `cmd_id`)

This separates different concerns into multiple classes, where each one deals only with limited responsibility. It should hopefully make it easier to scale as the amount of Commands grows (and at the moment we only have one really implemented, and 16 pending).

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with FE <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
