### PR TITLE
fix(cron): $CRON envvar to disambiguate terminal and cron invocation

### DIFF
--- a/crontab
+++ b/crontab
@@ -1,3 +1,3 @@
 # must be ended with a new line "LF" (Unix) and not "CRLF" (Windows)
-* * * * * php "$PROJECT_PATH/cron.php" >> /var/log/cron.log 2>&1
+* * * * * CRON=running php "$PROJECT_PATH/cron.php" >> /var/log/cron.log 2>&1
 # An empty line is required at the end of this file for a valid cron file.


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

instances_config.php (as defined in infra repo) checks if it's being invoked from terminal.. adding a CRON envvar makes it easy to recognize the special case when it is actually called from terminal, but it's ok because cron job is invoking it..

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with FE <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
