### PR TITLE
fix(csv): add user to standard room & other rooms (properly)

### DIFF
--- a/src/classes/models/User.php
+++ b/src/classes/models/User.php
@@ -1514,7 +1514,9 @@ class User
 
         foreach ($rooms as $room) {
           $this->roomRepository->insertOrUpdateUserToRoom($room['id'], $csvUser['id'], $updater_id);
+          $this->addUserRole($csvUser['id'], $user_level, $room['id']);
         }
+        $this->addUserToStandardRoom($csvUser['id']);
         $lineNumber++;
       }
     } catch (Exception $e) {


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

After importing CSV users can log in and see the rooms, but they can't post and they can't see the content of the rooms. This is because we manage user belonging to rooms in two places - relational table userXroom and JSON column of the user table. This PR adds the user to the user's role JSON field.

This PR also adds all the imported users to the standard room of the instance.

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with FE <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
