### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release docker image based on (1) commit sha (2) release tag version (3) :latest
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/aula-app/aula-backend/security/code-scanning/6](https://github.com/aula-app/aula-backend/security/code-scanning/6)

To fix the flagged issue, add a `permissions` block to the workflow file, restricting the GITHUB_TOKEN’s permissions to the minimum required. For this workflow, since its primary actions are checking out code (`actions/checkout@v4`), building Docker images, and pushing them (presumably with DockerHub credentials, not GITHUB_TOKEN), only `contents: read` is strictly necessary.  

The most conservative and generally recommended fix is to add a `permissions` block at the top level (recommended unless any job needs broader permissions). The permissions block should be added right after the workflow `name:` and before the `on:` section to apply to all jobs by default.

**Changes Required:**
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  after the `name:` line (after line 1).

No additional imports or further changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
