### PR TITLE
fix: remove unintelligible chars from password generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 <!-- here add all issues that haven't been released yet -->
 <!-- to release, assign a version number and move them there -->
 
+- feat(csv): schedule sending registration emails at a later point
+
+## 1.4.7
+
+- fix(csv): enable csv uploads for tech_admin
+
+## 1.4.6
+
 - feat(cron): deactivate bad commands
 - chore(cron): run scheduled commands every minute
 

--- a/src/classes/models/User.php
+++ b/src/classes/models/User.php
@@ -2264,7 +2264,7 @@ class User
     // pw generator 
 
     $j = 1;
-    $allowedCharacters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNPQRSTUVWXYZ_!@';
+    $allowedCharacters = '23456789abcdefghijklmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ_!@';
     $pass = '';
     $max = mb_strlen($allowedCharacters, '8bit') - 1;
     for ($i = 0; $i < $length; ++$i) {


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

<!-- Example:
After the last update it became apparent that we did fetch the new results, but didn't actually store them properly. This caused a glitch in the UI whenever the user would refresh the page.
-->

## Checklist

- [ ] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [ ] Backward and forward compatible with FE <!-- If not, please describe in detail and include other PR links -->
- [ ] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
