### PR TITLE
feat(user): admin can reset password for given user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 <!-- to release, assign a version number and move them there -->
 
 - feat(csv): schedule sending registration emails at a later point
+- feat(user): admins can reset password for a given user
 
 ## 1.4.7
 

--- a/src/classes/helpers/Permissions.php
+++ b/src/classes/helpers/Permissions.php
@@ -645,6 +645,11 @@ function checkPermissions($db, $crypt, $syslog, $model_name, $method, $arguments
         ]
       ],
 
+      "resetPasswordForUser" => [
+        "roles" => [
+          "admin"
+        ]
+      ]
     ],
 
     "Message" => [

--- a/src/classes/helpers/ResponseBuilder.php
+++ b/src/classes/helpers/ResponseBuilder.php
@@ -27,7 +27,7 @@ class ResponseBuilder
     return [
       'success' => false,
       'error_code' => $errorCode,
-      'error' => $errorCode != 1 ? null : $errorDescription,
+      'error' => $errorCode == 1 ? $errorDescription : null,
       'errors' => $errors,
       'data' => $errorCode == 1 ? null : $errors,
       'count' => 0

--- a/src/classes/models/User.php
+++ b/src/classes/models/User.php
@@ -22,14 +22,13 @@ class User
 {
   # User class provides a collection of methods dealing with everything around the user entity like adding or deleting etc.
 
-  private $db;
   private $responseBuilder;
   private $roomRepository;
 
   // @TODO: temporarily kept in User model, move after Laravel routing impl.
   private ResetPasswordForUserUseCase $resetPasswordForUserUseCase;
 
-  public function __construct($db, $crypt, $syslog)
+  public function __construct(private $db, private $crypt, private $syslog)
   {
     // db = database class, crypt = crypt class, $user_id_editor = user id that calls the methods (i.e. admin)
     $this->db = $db;
@@ -38,8 +37,6 @@ class User
     $this->converters = new Converters($db); // load converters
     $this->roomRepository = new RoomRepository($db);
     $this->responseBuilder = new ResponseBuilder();
-
-    $this->resetPasswordForUserUseCase = new ResetPasswordForUserUseCase($db, $crypt, $syslog, $this);
 
     global $email_host;
     global $email_port;
@@ -4021,7 +4018,7 @@ class User
   // @TODO: temporarily kept in User model, move after Laravel routing impl.
   public function resetPasswordForUser($user_id, $updater_id)
   {
-    return $this->resetPasswordForUserUseCase->execute($user_id, $updater_id);
+    return (new ResetPasswordForUserUseCase($this->db, $this->crypt, $this->syslog, $this))->execute($user_id, $updater_id);
   }
 }
 

--- a/src/classes/models/User.php
+++ b/src/classes/models/User.php
@@ -8,6 +8,7 @@ global $baseHelperDir;
 global $baseClassDir;
 require_once ($baseHelperDir . 'ResponseBuilder.php');
 require_once ($baseClassDir . 'repositories/RoomRepository.php');
+require_once ($baseClassDir . 'usecases/users/ResetPasswordForUserUseCase.php');
 
 if ($allowed_include == 1) {
 
@@ -25,6 +26,9 @@ class User
   private $responseBuilder;
   private $roomRepository;
 
+  // @TODO: temporarily kept in User model, move after Laravel routing impl.
+  private ResetPasswordForUserUseCase $resetPasswordForUserUseCase;
+
   public function __construct($db, $crypt, $syslog)
   {
     // db = database class, crypt = crypt class, $user_id_editor = user id that calls the methods (i.e. admin)
@@ -34,6 +38,8 @@ class User
     $this->converters = new Converters($db); // load converters
     $this->roomRepository = new RoomRepository($db);
     $this->responseBuilder = new ResponseBuilder();
+
+    $this->resetPasswordForUserUseCase = new ResetPasswordForUserUseCase($db, $crypt, $syslog, $this);
 
     global $email_host;
     global $email_port;
@@ -4011,5 +4017,11 @@ class User
       return false;
     }
   }
+
+  // @TODO: temporarily kept in User model, move after Laravel routing impl.
+  public function resetPasswordForUser($user_id, $updater_id)
+  {
+    return $this->resetPasswordForUserUseCase->execute($user_id, $updater_id);
+  }
 }
-?>
+

--- a/src/classes/repositories/UserRepository.php
+++ b/src/classes/repositories/UserRepository.php
@@ -1,0 +1,47 @@
+<?php
+
+class UserRepository
+{
+  private $db;
+
+  /**
+   ** @param Database $db
+   **/
+  public function __construct($db)
+  {
+    $this->db = $db;
+  }
+
+  public function patchUserBaseData($partialUser)
+  {
+    $setters = [];
+    $settersValues = [];
+    $conditionsValues = [];
+    $conditions = [];
+    foreach ($partialUser as $key => $value) {
+      if ($key === 'id' || $key === 'hash_id') {
+        $conditions[] = "{$key} = ?";
+        $conditionsValues[] = $value;
+        continue;
+      };
+      $setters[] = "{$key} = ?";
+      $settersValues[] = $value;
+    }
+
+    if (empty($conditions)) {
+      throw new RuntimeException("You must include some condition like 'id' or 'hash_id'.");
+    }
+
+    $settersString = implode(',', $setters);
+    $conditionsString = implode(' AND ', $conditions);
+    $query = <<<EOF
+      UPDATE {$this->db->au_users_basedata} SET
+        {$settersString}
+      WHERE
+        {$conditionsString};
+    EOF;
+    $stmt = $this->db->prepareStatement($query);
+    $stmt->execute(array_merge($settersValues, $conditionsValues));
+    return $stmt->fetch();
+  }
+}

--- a/src/classes/scheduler/CommandScheduler.php
+++ b/src/classes/scheduler/CommandScheduler.php
@@ -23,7 +23,7 @@ class CommandSchedulerForInstance
 
   public function dispatchAllDueCommands()
   {
-    $commands = $this->getDueCommands();
+    $commands = array_filter($this->getDueCommands());
 
     foreach ($commands as $command) {
       try {

--- a/src/classes/usecases/users/ResetPasswordForUserUseCase.php
+++ b/src/classes/usecases/users/ResetPasswordForUserUseCase.php
@@ -64,10 +64,4 @@ class ResetPasswordForUserUseCase
       }
     }
   }
-
-  protected function isValid(mixed $command): bool
-  {
-    $newStatus = intval($command['parameters']);
-    return $newStatus >= 0 && $newStatus <= 5;
-  }
 }

--- a/src/classes/usecases/users/ResetPasswordForUserUseCase.php
+++ b/src/classes/usecases/users/ResetPasswordForUserUseCase.php
@@ -1,0 +1,73 @@
+<?php
+
+require_once(__DIR__ . '/../../../../config/base_config.php');
+global $baseHelperDir;
+global $baseClassDir;
+require_once($baseHelperDir . 'ResponseBuilder.php');
+require_once($baseClassDir . 'repositories/UserRepository.php');
+
+class ResetPasswordForUserUseCase
+{
+  protected User $userModel;
+  protected Converters $converters;
+  protected ResponseBuilder $responseBuilder;
+  protected UserRepository $userRepo;
+
+  public function __construct(protected $db, $crypt, protected $syslog, $userModel = null)
+  {
+    $this->userModel = $userModel === null ? new User($db, $crypt, $syslog) : $userModel;
+    $this->converters = new Converters($db);
+    $this->responseBuilder = new ResponseBuilder();
+    $this->userRepo = new UserRepository($db);
+  }
+
+  public function execute($user_hash_id, $updater_id): mixed
+  {
+    $userId = $this->converters->checkUserId($user_hash_id);
+    $userBaseData = $this->userModel->getUserBaseData($userId);
+    if ($userBaseData['error_code'] != 0) {
+      error_log("Error fetching user data for user {$userId}");
+      return $this->responseBuilder->error();
+    }
+    $user = $userBaseData['data'];
+
+    $tempPass = $this->userModel->generate_pass();
+    if ($user['email']) {
+      // @TODO: https://github.com/aula-app/aula-frontend/issues/800
+      //   erase existing pass and temp pass
+      //     $patchedUser = $this->userRepo->patchUserBaseData([
+      //       'id' => $user['id'],
+      //       'temp_pw' => $tempPass,   // temp_pw is part of the JWT, so we will need to ask the user to renew the token
+      //       'refresh_token' => true,  // refresh_token flag atm means "you need to renew your JWT", and it's checked in check_jwt
+      //       'pw' => null
+      //     ]);
+      //   delete from au_change_password
+      //   insert into au_change_password
+      //   send email
+      return $this->responseBuilder->error(1, errorDescription: "Not yet implemented");
+    } else {
+      $this->db->beginTransaction("SERIALIZABLE");
+      try {
+        $patchedUser = $this->userRepo->patchUserBaseData([
+          'hash_id' => $user_hash_id,
+          'temp_pw' => $tempPass,   // temp_pw is part of the JWT, so we will need to ask the user to renew the token
+          'refresh_token' => true,  // refresh_token flag atm means "you need to renew your JWT", and it's checked in check_jwt
+          'pw' => null
+        ]);
+        $this->syslog->addSystemEvent(0, "User's ({$user_hash_id}) password was reset by {$updater_id}", 0, "", 1, $updater_id);
+        $this->db->commitTransaction();
+        return $this->responseBuilder->success($patchedUser);
+      } catch (\Throwable $t) {
+        error_log("Resetting password for user {$user_hash_id} has failed due to: " . $t->getMessage());
+        $this->db->rollbackTransaction();
+        return $this->responseBuilder->error();
+      }
+    }
+  }
+
+  protected function isValid(mixed $command): bool
+  {
+    $newStatus = intval($command['parameters']);
+    return $newStatus >= 0 && $newStatus <= 5;
+  }
+}


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

This PR introduces ability for admin to reset password of user. This is currently implemented only for users that have no email. The FE makes sure that in case a temporary password already exists for a user, it can be shown to the admin, otherwise the Reset Password button will be shown. This is implemented in https://github.com/aula-app/aula-frontend/pull/874

In the future, we should implement https://github.com/aula-app/aula-frontend/issues/800 for users with registered email. This PR offers flexibility for that future implementation.

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- ~[] Backward and forward compatible with FE~ ** this BE PR must be released before this FE PR is released: https://github.com/aula-app/aula-frontend/pull/874**
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
