### PR TITLE
Do not count two times super users with voting rights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 <!-- to release, assign a version number and move them there -->
 
 - feat(csv): schedule sending registration emails at a later point
+- fix(user count in quorum): fix super user roles with voting rights being counted two times
 
 ## 1.4.7
 

--- a/src/classes/models/Idea.php
+++ b/src/classes/models/Idea.php
@@ -119,6 +119,7 @@ class Idea
       SELECT id 
       FROM {$this->db->au_users_basedata}
       WHERE
+        userlevel NOT IN (41,45) AND
         id in (SELECT user_id FROM {$this->db->au_rel_rooms_users} WHERE room_id = :room_id)
         AND EXISTS (
           SELECT 1


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Fix https://github.com/aula-app/aula-frontend/issues/601

user roles with voting rights (super moderator with voting rights and principal with voting rights) were being counted two times in the voting quorum. Just a note: Don't you think that it's a bit weird that these users can also be added to a room with roles that don't have voting rights like Guest.

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with FE <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [x] Must be deployed ASAP (HOTFIX)
