### PR TITLE
fix: missing reference to $code

### DIFF
--- a/src/controllers/forgot_password.php
+++ b/src/controllers/forgot_password.php
@@ -62,7 +62,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     
     // @TODO: remove the sprintf call after the next deployment, it will be noop once the template is updated
     $email_body = sprintf($email_forgot_password_body, $realname, $secret, $secret);
-    $email_body = str_replace("<CODE>", $code, $email_body);
+    $email_body = str_replace("<CODE>", $instance->code, $email_body);
     $email_body = str_replace("<NAME>", $realname, $email_body);
     $email_body = str_replace("<SECRET_KEY>", $secret, $email_body);
 


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

https://github.com/aula-app/aula-backend/pull/297 introduced the bug of not sending instance code as query param as part of reset password URL. it was deployed to prod on 2025-09-30T17:38.. 

Fixes https://github.com/aula-app/aula-manager/issues/23

## Checklist

- [ ] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [x] Must be deployed ASAP (HOTFIX)
- [x] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
