### PR TITLE
Add new type of permission check to allow tech admin to edit main room

### DIFF
--- a/src/classes/helpers/Permissions.php
+++ b/src/classes/helpers/Permissions.php
@@ -319,7 +319,8 @@ function checkPermissions($db, $crypt, $syslog, $model_name, $method, $arguments
       ],
 
       "editRoom" => [
-        "roles" => ["admin"]
+        "open_roles" => ["admin"],
+        "checks" => ["method:canEditMainRoom"]
       ],
 
       "getRooms" => [
@@ -1374,8 +1375,16 @@ function checkPermissions($db, $crypt, $syslog, $model_name, $method, $arguments
           $total_checks = 0;
           foreach ($checks as $c) {
             $cparts = explode(":", $c);
-            if (${$cparts[0]} == $arguments[$cparts[1]]) {
-              $total_checks += 1;
+            if ($cparts[0] != "method") {
+              if (${$cparts[0]} == $arguments[$cparts[1]]) {
+                $total_checks += 1;
+              }
+            } else {
+              $check_method = $cparts[1];
+              $passed_check = $model->$check_method($user_id, $userlevel, $arguments);
+              if ($passed_check) {
+                 $total_checks += 1;
+              }
             }
           }
           if (count($checks) == $total_checks) {

--- a/src/classes/models/Room.php
+++ b/src/classes/models/Room.php
@@ -571,6 +571,8 @@ class Room
   }
 
   public function getUsersInRoom($room_id, $status = -1, $offset = 0, $limit = 0, $orderby = 3, $asc = 0)
+
+    
   {
     /* returns users (associative array)
     $status (int) relates to the status of the users => 0=inactive, 1=active, 2=suspended, 3=archived, defaults to active (1)
@@ -824,6 +826,19 @@ class Room
     }
   }
 
+  public function canEditMainRoom($user_id, $userlevel, $arguments) {
+    if ($userlevel != 60) {
+      return false;
+    }
+
+    try {
+      $room = $this->getRoomBaseData($arguments["room_id"])["data"];
+      if ($room["type"] == 1)
+        return true;
+    } catch(Exception $e) {
+      return false;
+    }
+  }
 
   public function editRoom($room_id, $room_name, $description_public = "", $description_internal = "", $internal_info = "", $status = 1, $access_code = "", $order_importance = 10, $updater_id = 0, $phase_duration_0 = 0, $phase_duration_1 = 0, $phase_duration_2 = 0, $phase_duration_3 = 0, $phase_duration_4 = 0)
   {


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Fix #312 

Now in the permissions checks table a new check can be added as:

"checks" => ["method:METHOD-CHECKER-NAME"]

if the first argument is "method" the METHOD-CHECKER-NAME for the model will be called passing user_id, userlevel and the method call arguments. If the first value is not "method", the check will work as before.

<!-- Example:
After the last update it became apparent that we did fetch the new results, but didn't actually store them properly. This caused a glitch in the UI whenever the user would refresh the page.
-->

## Checklist

- [x ] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [x] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
