### PR TITLE
Prevent the use of extra_where by the frontend

### DIFF
--- a/src/controllers/model.php
+++ b/src/controllers/model.php
@@ -51,6 +51,9 @@ if ($check_jwt["success"]) {
   $method = $input["method"];
 
   if (array_key_exists("arguments", $input)) {
+    if (array_key_exists("extra_where", $input["arguments"])) {
+      unset($input["arguments"]["extra_where"]) ;
+    }
     $arguments = $input["arguments"];
   } else {
     $arguments = [];


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

<!-- Example:
After the last update it became apparent that we did fetch the new results, but didn't actually store them properly. This caused a glitch in the UI whenever the user would refresh the page.
-->

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [x] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
