### PR TITLE
fix(email): add extra email headers to battle SPAM filters

### DIFF
--- a/src/classes/models/User.php
+++ b/src/classes/models/User.php
@@ -2523,7 +2523,8 @@ class User
           'Reply-To' => $email_address_support,
           'MIME-Version' => $mime,
           'Content-type' => $content,
-          'message-id' => time() .'-' . md5($email_from . $email) . '@' . $_SERVER['SERVER_NAME']
+          'message-id' => time() .'-' . md5($email_from . $email) . '@' . $_SERVER['SERVER_NAME'],
+          'Date' => date('r')
         );
 
         $email_body = str_replace("<SECRET_KEY>", $secret, $email_creation_body);

--- a/src/classes/usecases/commands/SendEmailHandler.php
+++ b/src/classes/usecases/commands/SendEmailHandler.php
@@ -61,7 +61,9 @@ class SendEmailHandler extends CommandHandler
       'Subject' => $email_subject,
       'Reply-To' => $email_address,
       'MIME-Version' => $mime,
-      'Content-type' => $content
+      'Content-type' => $content,
+      'Message-Id' => time() .'-' . md5($email_from . $email) . '@' . $_SERVER['SERVER_NAME'],
+      'Date' => date('r')
     );
 
     $email_body = str_replace("<SECRET_KEY>", $secret, $email_body);

--- a/src/controllers/forgot_password.php
+++ b/src/controllers/forgot_password.php
@@ -58,12 +58,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $content = "text/html; charset=utf-8";
     $mime = "1.0";
 
-    $headers = array ('From' => $email_from,
-    	'To' => $email,
-    	'Subject' => 	$email_forgot_password_subject,
+    $headers = array (
+      'From' => $email_from,
+      'To' => $email,
+      'Subject' => 	$email_forgot_password_subject,
     	'Reply-To' => $email_address_support,
-    	'MIME-Version' => $mime,
-    	'Content-type' => $content);
+      'MIME-Version' => $mime,
+      'Content-type' => $content,
+      'Message-Id' => time() .'-' . md5($email_from . $email) . '@' . $_SERVER['SERVER_NAME'],
+      'Date' => date('r')
+    );
 
     $email_body = $email_forgot_password_body;
     $email_body = str_replace("<CODE>", $instance->code, $email_body);


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Follow up to https://github.com/aula-app/aula-backend/pull/327:
1. I forgot to add this header to other places.
2. I added another header `Date` for even better score

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
