### PR TITLE
fix(security): don't leak info if user is on our platform

### DIFF
--- a/src/controllers/forgot_password.php
+++ b/src/controllers/forgot_password.php
@@ -76,8 +76,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $email_body = str_replace("<SECRET_KEY>", $secret, $email_body);
 
     $mail = $smtp->send($email, $headers, $email_body);
-
-    header('Content-Type: application/json; charset=utf-8');
-    echo json_encode(["success" => true]);
   };
+
+  header('Content-Type: application/json; charset=utf-8');
+  echo json_encode(["success" => true]);
 }


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

If we have a positive and negative response on "forgot password" page, info about an email being registered in aula leaks.

## Checklist

- [ ] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
