### PR TITLE
fix(ci): docker build commands missing `.`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Push Docker image tag
         run: docker push $IMAGE_TAG_SHORT_SHA
 
-      - name: '[legacy] Add IMAGE_TAG_LEGACY_SHORT_SHA env property with commit short sha'
+      - name: "[legacy] Add IMAGE_TAG_LEGACY_SHORT_SHA env property with commit short sha"
         run: echo "IMAGE_TAG_LEGACY_SHORT_SHA=aulaapp/aula-backend:legacy-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
-      - name: '[legacy] Build and tag legacy Docker image'
-        run: docker build -f legacy/Dockerfile -t $IMAGE_TAG_LEGACY_SHORT_SHA
+      - name: "[legacy] Build and tag legacy Docker image"
+        run: docker build -f legacy/Dockerfile -t $IMAGE_TAG_LEGACY_SHORT_SHA .
 
-      - name: '[legacy] Push Docker legacy image tags'
+      - name: "[legacy] Push Docker legacy image tags"
         run: docker push $IMAGE_TAG_LEGACY_SHORT_SHA

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and tag Docker images
-        run: docker build -f legacy/Dockerfile -t $IMAGE_TAG_VERSION
+        run: docker build -f legacy/Dockerfile -t $IMAGE_TAG_VERSION .
 
       - name: Push Docker image tags
         run: docker push $IMAGE_TAG_VERSION
@@ -37,7 +37,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and tag Docker images
-        run: docker build -f ./Dockerfile -t $IMAGE_TAG_VERSION -t $IMAGE_TAG_LATEST
+        run: docker build -f ./Dockerfile -t $IMAGE_TAG_VERSION -t $IMAGE_TAG_LATEST .
 
       - name: Push Docker image tags
         run: |


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

fix borken ci
<img width="1508" height="932" alt="image" src="https://github.com/user-attachments/assets/a0023219-5269-4813-a9bd-31e86b7ca7c3" />


## Checklist

- [ ] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
