### PR TITLE
fix(ci): releases failing when semver contains plus character

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build docker image based on commit sha
+name: Build and push docker images based on git commit sha
 permissions:
   contents: read
 
@@ -18,7 +18,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Add IMAGE_TAG_SHORT_SHA env property with commit short sha
-        run: echo "IMAGE_TAG_SHORT_SHA=aulaapp/aula-backend:$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "IMAGE_TAG_SHORT_SHA=${{ github.event.repository.name }}:$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Build and tag Docker image
         run: docker build -t $IMAGE_TAG_SHORT_SHA .
@@ -27,7 +27,7 @@ jobs:
         run: docker push $IMAGE_TAG_SHORT_SHA
 
       - name: "[legacy] Add IMAGE_TAG_LEGACY_SHORT_SHA env property with commit short sha"
-        run: echo "IMAGE_TAG_LEGACY_SHORT_SHA=aulaapp/aula-backend:legacy-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+        run: echo "IMAGE_TAG_LEGACY_SHORT_SHA=${{ github.event.repository.name }}:legacy-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: "[legacy] Build and tag legacy Docker image"
         working-directory: ./legacy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release docker image based on (1) commit sha (2) release tag version (3) :latest
+name: Release docker image based on release tag version and :latest
 permissions:
   contents: read
 
@@ -7,11 +7,20 @@ on:
     types: [published]
 
 env:
-  IMAGE_TAG_LATEST: "aulaapp/aula-backend:latest"
-  IMAGE_TAG_VERSION: "aulaapp/aula-backend:${{ github.event.release.tag_name }}"
+  IMAGE_TAG_LATEST: "${{ github.event.repository.name }}:latest"
 
 jobs:
+  sanitize_tag:
+    runs-on: [self-hosted, cicd]
+    steps:
+      - name: Substitute illegal Docker image tag characters
+        run: |
+          echo "${{ github.event.release.tag_name }}" | \
+            sed 's/[^a-zA-Z0-9_.-]/_/g' | \
+            (echo -n "IMAGE_TAG_VERSION=${{ github.event.repository.name }}:" && cat) \
+          >> $GITHUB_ENV
   build_v1:
+    needs: sanitize_tag
     if: ${{ startsWith(github.event.release.tag_name, 'v1') }}
     runs-on: [self-hosted, cicd]
     steps:
@@ -28,6 +37,7 @@ jobs:
       - name: Push Docker image tags
         run: docker push $IMAGE_TAG_VERSION
   build_v2:
+    needs: sanitize_tag
     if: ${{ startsWith(github.event.release.tag_name, 'v2') }}
     runs-on: [self-hosted, cicd]
     steps:


### PR DESCRIPTION
docker image tags don't support `+` in their name, so we replace it with an underscore `_`

## Context <!-- ie. explanations, background, documentation -->

<!-- Example:
After the last update it became apparent that we did fetch the new results, but didn't actually store them properly. This caused a glitch in the UI whenever the user would refresh the page.
-->

## Checklist

- [ ] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
