### PR TITLE
fix: github worlflow pass envvars as job outputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,15 @@ jobs:
   sanitize_tag:
     runs-on: [self-hosted, cicd]
     steps:
-      - name: Substitute illegal Docker image tag characters
+      - id: sanitize
+        name: Substitute illegal Docker image tag characters
         run: |
           echo "${{ github.event.release.tag_name }}" | \
             sed 's/[^a-zA-Z0-9_.-]/_/g' | \
             (echo -n "IMAGE_TAG_VERSION=aulaapp/${{ github.event.repository.name }}:" && cat) \
-          >> $GITHUB_ENV
+          >> $GITHUB_OUTPUT
+    outputs:
+      IMAGE_TAG_VERSION: ${{ steps.sanitize.outputs.IMAGE_TAG_VERSION }}
   build_v1:
     needs: sanitize_tag
     if: ${{ startsWith(github.event.release.tag_name, 'v1') }}
@@ -32,10 +35,10 @@ jobs:
 
       - name: Build and tag Docker images
         working-directory: ./legacy
-        run: docker build -t "${{ env.IMAGE_TAG_VERSION }}" .
+        run: docker build -t "${{ needs.sanitize_tag.outputs.IMAGE_TAG_VERSION }}" .
 
       - name: Push Docker image tags
-        run: docker push "${{ env.IMAGE_TAG_VERSION }}"
+        run: docker push "${{ needs.sanitize_tag.outputs.IMAGE_TAG_VERSION }}"
   build_v2:
     needs: sanitize_tag
     if: ${{ startsWith(github.event.release.tag_name, 'v2') }}
@@ -48,9 +51,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and tag Docker images
-        run: docker build -t "${{ env.IMAGE_TAG_VERSION }}" -t $IMAGE_TAG_LATEST .
+        run: docker build -t "${{ needs.sanitize_tag.outputs.IMAGE_TAG_VERSION }}" -t $IMAGE_TAG_LATEST .
 
       - name: Push Docker image tags
         run: |
-          docker push "${{ env.IMAGE_TAG_VERSION }}" && \
+          docker push "${{ needs.sanitize_tag.outputs.IMAGE_TAG_VERSION }}" && \
           docker push $IMAGE_TAG_LATEST


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

<!-- Example:
After the last update it became apparent that we did fetch the new results, but didn't actually store them properly. This caused a glitch in the UI whenever the user would refresh the page.
-->

## Checklist

- [ ] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
