### PR TITLE
fix: getUsers filter for room per r.hash_id

### DIFF
--- a/legacy/src/classes/models/User.php
+++ b/legacy/src/classes/models/User.php
@@ -1819,6 +1819,7 @@ class User
         u.username,
         u.email,
         u.userlevel,
+        u.about_me,
         u.temp_pw,
         u.last_update
       FROM


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

### getUsersByRoom
1. At the moment `getUsersByRoom` returns various fields of User model.
2. In some situations all of these fields are used, in others only `u.hash_id` is used.

### getUsers
1. At the moment `getUsers` has `$room_id` argument which fails:
  a. when given `r.hash_id` instead of internal id
  b. when given any value because the SQL query doesn't use `:room_id`

### future steps
1. Fix the `getUsers` filter for `room_id`.
2. We want minimal data exposure, so all scenarios where `getUsersByRoom` is required to return rich data response should be migrated to `getUsers` with `room_id` filter.
3. Wait for the aula-frontend fix to be propagated to most users.
4. Fix the `getUsersByRoom` so it doesn't return the now-unused fields in the response -> https://github.com/aula-app/aula-backend/pull/372

**This PR tackles the first of the "future steps". Step 1. It fixes `getUsers` to work with `room_id` filter so that it searches in the user.rooms JSON for the specified room (it doesn't double-check in the rooms table).**

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
~- [ ] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases)~ **see "future steps" section above ^^**
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
