### PR TITLE
Put getUserGDPRData back to legacy User class

### DIFF
--- a/legacy/src/classes/models/User.php
+++ b/legacy/src/classes/models/User.php
@@ -256,6 +256,111 @@ class User
 
   } // end function
 
+  public function getUserGDPRData($user_id)
+  {
+    //retrieves all data associated to a certain user according to GDPR and returns it
+
+    /* returns user base data for a specified db id */
+    $user_id = $this->converters->checkUserId($user_id); // checks user id and converts user id to db user id if necessary (when user hash id was passed)
+
+    $stmt = $this->db->query('SELECT * FROM ' . $this->db->au_users_basedata . ' WHERE id = :id');
+    $this->db->bind(':id', $user_id); // bind userid
+
+    // init output array
+    $gdpr = [];
+
+    // init data found helper
+    $data_found = false;
+
+    $users = $this->db->resultSet();
+
+    if (count($users) < 1) {
+      // no data found / user not existent
+      // return error code
+      $returnvalue['success'] = true; // set return value
+      $returnvalue['error_code'] = 2; // error code
+      $returnvalue['data'] = false; // returned data
+      $returnvalue['count'] = 0; // returned count of datasets
+
+      return $returnvalue;
+
+    } else {
+      // data found, continue...
+      $data_found = true;
+    }
+
+    /* User basedata */
+
+    $gdpr['realname'] = $users[0]['realname'];
+    $gdpr['displayname'] = $users[0]['displayname'];
+    $gdpr['username'] = $users[0]['username'];
+    $gdpr['email'] = $users[0]['email'];
+    $gdpr['about_me'] = $users[0]['about_me'];
+    $gdpr['user_created'] = $users[0]['created'];
+    $gdpr['user_last_update'] = $users[0]['last_update'];
+    $gdpr['user_last_login'] = $users[0]['last_login'];
+    $gdpr['user_level'] = $users[0]['userlevel'];
+
+    // get ideas
+    $stmt = $this->db->query('SELECT content, last_update, created FROM ' . $this->db->au_ideas . ' WHERE user_id = :id');
+    $this->db->bind(':id', $user_id); // bind userid
+
+    $ideas = $this->db->resultSet();
+
+    if (count($ideas) > 0) {
+      // data found
+      $data_found = true;
+    }
+
+    // iterate through ideas, concatenate
+    $gdpr['ideas'] = '';
+
+    foreach ($ideas as $idea) {
+      $gdpr['ideas'] .= $idea['content'] . ", IDEA CREATED: " . $idea['created'] . ", IDEA LAST UPDATE: " . $idea['last_update'] . "*§$";
+    }
+
+    // get comments
+    $stmt = $this->db->query('SELECT content, created, last_update FROM ' . $this->db->au_comments . ' WHERE user_id = :id');
+    $this->db->bind(':id', $user_id); // bind userid
+
+    $comments = $this->db->resultSet();
+
+    if (count($comments) > 0) {
+      // data found
+      $data_found = true;
+
+    }
+
+    // iterate through comments, concatenate
+    $gdpr['comments'] = '';
+
+    foreach ($comments as $comment) {
+      $gdpr['comments'] .= $comment['content'] . ", COMMENT CREATED: " . $comment['created'] . ", COMMENT LAST UPDATE: " . $comment['last_update'] . "*§$";
+    }
+
+
+    if (!$data_found) {
+      // nothing found, return error code
+      $returnvalue['success'] = true; // set return value
+      $returnvalue['error_code'] = 2; // error code
+      $returnvalue['data'] = false; // returned data
+      $returnvalue['count'] = 0; // returned count of datasets
+
+      return $returnvalue;
+    } else {
+      // everything ok, return values
+      $returnvalue['success'] = true; // set return value
+      $returnvalue['error_code'] = 0; // error code
+      $returnvalue['data'] = $gdpr; // returned data
+      $returnvalue['count'] = 1; // returned count of datasets
+
+      return $returnvalue;
+
+    } // end else
+
+    } // end function
+
+
   public function getDelegationStatus($user_id, $topic_id)
   {
     $user_id = $this->converters->checkUserId($user_id); // checks user id and converts user id to db user id if necessary (when user hash id was passed)


### PR DESCRIPTION
This function was deleted in a code cleanup but it is being used

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [x] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
