### PR TITLE
fix: standard room should have hash_id

### DIFF
--- a/app/Console/Commands/CreateTenant.php
+++ b/app/Console/Commands/CreateTenant.php
@@ -273,10 +273,14 @@ class CreateTenant extends Command
     private function insertInitialSystemData(): void
     {
         $now = now();
+        $testrand = rand(100, 10000000);
+        $appendix = microtime(true) . $testrand;
+        $hash_id = md5('Schule' . $appendix);
 
         DB::table('au_rooms')->insert([
             'room_name' => 'Schule',
             'description_internal' => null,
+            'hash_id' => hash_id,
             'status' => 1,
             'type' => 1,
         ]);


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Automated tests were failing on this.

## Checklist

- [ ] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [ ] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [ ] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
