### PR TITLE
fix: create instance should include standard room hash_id

### DIFF
--- a/app/Console/Commands/CreateTenant.php
+++ b/app/Console/Commands/CreateTenant.php
@@ -274,13 +274,13 @@ class CreateTenant extends Command
     {
         $now = now();
         $testrand = rand(100, 10000000);
-        $appendix = microtime(true) . $testrand;
-        $hash_id = md5('Schule' . $appendix);
+        $appendix = microtime(true).$testrand;
+        $hash_id = md5('Schule'.$appendix);
 
         DB::table('au_rooms')->insert([
             'room_name' => 'Schule',
             'description_internal' => null,
-            'hash_id' => hash_id,
+            'hash_id' => $hash_id,
             'status' => 1,
             'type' => 1,
         ]);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,6 @@ include:
   # aula-backend-legacy service & aula_local network
   - ./legacy/docker-compose.yml
 
-include:
-  - ./legacy/docker-compose.yml
-
 services:
   aula-backend.v2:
     build:


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Tested manually and noticed an issue.

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
