### PR TITLE
fix: create instance init pass urls

### DIFF
--- a/app/Console/Commands/CreateTenant.php
+++ b/app/Console/Commands/CreateTenant.php
@@ -106,6 +106,10 @@ class CreateTenant extends Command
         // Create the tenant
         $this->info('Creating tenant...');
 
+        $baseUrl = config('app.url');
+        $adminSecret = Str::random(64);
+        $secondAdminSecret = Str::random(64);
+
         try {
             $tenant = Tenant::create([
                 'name' => $tenantName,
@@ -118,6 +122,8 @@ class CreateTenant extends Command
                 'admin2_name' => $secondAdminFullName,
                 'admin2_username' => $secondAdminUsername,
                 'admin2_email' => $secondAdminEmail,
+                'admin1_init_pass_url' => "{$baseUrl}/password/{$adminSecret}?code={$instanceCode}",
+                'admin2_init_pass_url' => "{$baseUrl}/password/{$secondAdminSecret}?code={$instanceCode}",
             ]);
 
             $this->info("Tenant created with ID: {$tenant->id}");
@@ -134,9 +140,9 @@ class CreateTenant extends Command
 
         try {
             $tenant->run(function () use (
-                $tenantName, $adminUsername, $adminFullName, $adminEmail,
-                $secondAdminUsername, $secondAdminFullName, $secondAdminEmail,
-                $instanceCode
+                $tenantName, $instanceCode,
+                $adminUsername, $adminFullName, $adminEmail, $adminSecret,
+                $secondAdminUsername, $secondAdminFullName, $secondAdminEmail, $secondAdminSecret
             ) {
                 $now = now();
 
@@ -161,7 +167,6 @@ class CreateTenant extends Command
                 ]);
 
                 // Create password reset entry for first admin
-                $adminSecret = Str::random(64);
                 DB::table('au_change_password')->insert([
                     'user_id' => $adminId,
                     'secret' => $adminSecret,
@@ -187,14 +192,11 @@ class CreateTenant extends Command
                 ]);
 
                 // Create password reset entry for second admin
-                $secondAdminSecret = Str::random(64);
                 DB::table('au_change_password')->insert([
                     'user_id' => $secondAdminId,
                     'secret' => $secondAdminSecret,
                     'created_at' => $now,
                 ]);
-
-                $baseUrl = config('app.url');
 
                 $this->newLine();
                 $this->info('=== Password Reset URLs ===');
@@ -204,12 +206,6 @@ class CreateTenant extends Command
                 $this->line("Second Admin ({$secondAdminUsername}):");
                 $this->line("  {$baseUrl}/password/{$secondAdminSecret}?code={$instanceCode}");
             });
-
-            // Store init password URLs on the tenant record
-            $tenant->update([
-                'admin1_init_pass_url' => 'pending',
-                'admin2_init_pass_url' => 'pending',
-            ]);
 
         } catch (\Exception $e) {
             $this->error("Failed to create admin users: {$e->getMessage()}");
@@ -223,7 +219,7 @@ class CreateTenant extends Command
         return self::SUCCESS;
     }
 
-    protected function appendLegacyConfigInplace($configFile, $newConfig)
+    protected function appendLegacyConfigInplace($configFile, $newConfig): bool
     {
         $reading = fopen($configFile, 'r');
         if (! $reading) {


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

tenants table didn't get updated URLs for setting the initial passwords of admin1 and admin2

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
