### PR TITLE
fix: revert inserting allow_registration=0 for non-default value column

### DIFF
--- a/app/Console/Commands/CreateTenant.php
+++ b/app/Console/Commands/CreateTenant.php
@@ -297,6 +297,7 @@ class CreateTenant extends Command
 
         DB::table('au_system_global_config')->insert([
             'name' => $name,
+            'allow_registration' => 0,
         ]);
     }
 }


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

<!-- Example:
After the last update it became apparent that we did fetch the new results, but didn't actually store them properly. This caused a glitch in the UI whenever the user would refresh the page.
-->

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [x] Must be deployed ASAP (HOTFIX) **we should release this soon so we can create new tenants**
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
