### PR TITLE
fix: some recipients receive multiple emails

### DIFF
--- a/app/Console/Commands/SendTenantStatisticsReport.php
+++ b/app/Console/Commands/SendTenantStatisticsReport.php
@@ -99,16 +99,17 @@ class SendTenantStatisticsReport extends Command
     private function sendReport(string $csv, string $filename, array $recipients, int $tenantCount): void
     {
         $mailable = new TenantStatisticsReport($csv, $filename, $tenantCount);
-        $recipientsAsString = implode(',', $recipients);
 
-        try {
-            Mail::to($recipients)->send($mailable);
-            $this->info("Report sent to: {$recipientsAsString}");
-            Log::debug("Report sent to: {$recipientsAsString}");
-        } catch (Throwable $e) {
-            $errorMsg = "Failed to send report to {$recipientsAsString}: {$e->getMessage()}";
-            $this->error($errorMsg);
-            Log::warning($errorMsg);
+        foreach ($recipients as $recipient) {
+            try {
+                Mail::to($recipient)->send(clone $mailable);
+                $this->info("Report sent to: {$recipient}");
+                Log::debug("Report sent to: {$recipient}");
+            } catch (Throwable $e) {
+                $errorMsg = "Failed to send report to {$recipient}: {$e->getMessage()}";
+                $this->error($errorMsg);
+                Log::warning($errorMsg);
+            }
         }
     }
 

--- a/app/Console/Commands/SendTenantStatisticsReport.php
+++ b/app/Console/Commands/SendTenantStatisticsReport.php
@@ -99,17 +99,16 @@ class SendTenantStatisticsReport extends Command
     private function sendReport(string $csv, string $filename, array $recipients, int $tenantCount): void
     {
         $mailable = new TenantStatisticsReport($csv, $filename, $tenantCount);
+        $recipientsAsString = implode(',', $recipients);
 
-        foreach ($recipients as $recipient) {
-            try {
-                Mail::to($recipient)->send($mailable);
-                $this->info("Report sent to: {$recipient}");
-                Log::debug("Report sent to: {$recipient}");
-            } catch (Throwable $e) {
-                $errorMsg = "Failed to send report to {$recipient}: {$e->getMessage()}";
-                $this->error($errorMsg);
-                Log::warning($errorMsg);
-            }
+        try {
+            Mail::to($recipients)->send($mailable);
+            $this->info("Report sent to: {$recipientsAsString}");
+            Log::debug("Report sent to: {$recipientsAsString}");
+        } catch (Throwable $e) {
+            $errorMsg = "Failed to send report to {$recipientsAsString}: {$e->getMessage()}";
+            $this->error($errorMsg);
+            Log::warning($errorMsg);
         }
     }
 


### PR DESCRIPTION
## Problem

when the recipient list is: A,B,C:
A: receives emails with
  to: A
  to: A,B
  to: A,B,C
B: receives emails with
  to: B
  to: B,C
C: receives one email with
  to: C

when looking into rapidmail, the recipient (`$.to`) is always the single one as it should be, but there's `$.mime` field that contains always all recipients..

<img width="400" src="https://github.com/user-attachments/assets/3b02d4e4-b652-4d10-9010-35890dc5a791" />


so i would assume either all users receive emails with all other recipients in `to:` OR they receive emails destined to that single user.. however, in reality, it behaves strange..

## Fix

Simply send one email to all recipients at once instead of splitting per recipient.

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
