### PR TITLE
disallow creation of actions in the past

### DIFF
--- a/legacy/src/classes/models/Command.php
+++ b/legacy/src/classes/models/Command.php
@@ -184,6 +184,18 @@ class Command
     $date_start = trim($date_start);
     // auto set date to midnight for now
     $date_start = date_format(date_create($date_start),"Y-m-d 00:00:00");
+    $date_now = date_format(date_create(),"Y-m-d 00:00:00");
+
+    // dates are formatted equally, so we can safely string compare
+    if ($date_start < $date_now) {
+      $this->syslog->addSystemEvent(1, "Tried to create action in the past", 0, "", 1);
+      return [
+        'success' => false,
+        'error_code' => 1,
+        'data' => false,
+        'count' => 0,
+      ];
+    }
 
     if ($target_id > 0) {
       $target_id = intval($target_id);

--- a/legacy/src/classes/models/Command.php
+++ b/legacy/src/classes/models/Command.php
@@ -187,7 +187,8 @@ class Command
     $date_now = date_format(date_create(),"Y-m-d 00:00:00");
 
     // dates are formatted equally, so we can safely string compare
-    if ($date_start < $date_now) {
+    // n.b. less-than-equal, date_start must be at least tomorrow
+    if ($date_start <= $date_now) {
       $this->syslog->addSystemEvent(1, "Tried to create action in the past", 0, "", 1);
       return [
         'success' => false,


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

<!-- Example:
After the last update it became apparent that we did fetch the new results, but didn't actually store them properly. This caused a glitch in the UI whenever the user would refresh the page.
-->

- the frontend should probably *display* the error?
- see also timezone discussion in https://github.com/aula-app/aula-frontend/pull/1114

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [ ] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links --> :question: not sure about this
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
