### PR TITLE
fix: provide a server name for legacy cron

### DIFF
--- a/legacy/src/classes/usecases/commands/SendEmailHandler.php
+++ b/legacy/src/classes/usecases/commands/SendEmailHandler.php
@@ -55,6 +55,9 @@ class SendEmailHandler extends CommandHandler
         break;
     }
 
+    // gethostname() for cli
+    $server_name = $_SERVER['SERVER_NAME'] ?? gethostname();
+
     $headers = array(
       'From' => $email_from,
       'To' => $email,
@@ -62,7 +65,7 @@ class SendEmailHandler extends CommandHandler
       'Reply-To' => $email_address,
       'MIME-Version' => $mime,
       'Content-type' => $content,
-      'Message-Id' => time() .'-' . md5($email_from . $email) . '@' . $_SERVER['SERVER_NAME'],
+      'Message-Id' => time() . '-' . md5($email_from . $email) . '@' . $server_name,
       'Date' => date('r')
     );
 


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

there is no `$_SERVER['SERVER_NAME']` in cron/cli, and this warning annoyed me while working on something else. 

<!-- Example:
After the last update it became apparent that we did fetch the new results, but didn't actually store them properly. This caused a glitch in the UI whenever the user would refresh the page.
-->

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
