### PR TITLE
Feat/473 Xdebug with VSCode in legacy backend

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,5 +14,8 @@ trim_trailing_whitespace = false
 [*.{yml,yaml}]
 indent_size = 2
 
+[*.json]
+indent_size = 2
+
 [*.php]
 indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ _ide_helper.php
 /.junie
 /.nova
 /.phpunit.cache
-/.vscode
 /.zed
 /auth.json
 /node_modules

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Listen for Xdebug",
+      "type": "php",
+      "request": "launch",
+      "port": 9003,
+      "pathMappings": {
+        "/var/www/html/api": "${workspaceFolder}/legacy/src",
+        "/var/www/html/config": "${workspaceFolder}/legacy/config",
+        "/var/www/html/cron.php": "${workspaceFolder}/legacy/cron.php"
+      },
+      "log": true
+    }
+  ]
+}

--- a/legacy/Dockerfile
+++ b/legacy/Dockerfile
@@ -12,7 +12,8 @@ EXPOSE 80
 WORKDIR $PROJECT_PATH
 USER root
 
-# Utilities, Apache, PHP, and supplementary programs which the application requires
+# Utilities, Apache, PHP, and supplementary programs which the application requires,
+# prevent autoloading xdebug
 RUN set -eux; apt update -q && \
   apt install -yqq curl cron gosu \
     apache2 libapache2-mod-php php8.3 \
@@ -24,6 +25,7 @@ RUN set -eux; apt update -q && \
   apt purge -yq patch software-properties-common && \
   apt autoremove -yqq && \
   apt clean && \
+  rm /etc/php/8.3/cli/conf.d/20-xdebug.ini /etc/php/8.3/apache2/conf.d/20-xdebug.ini && \
   rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
 # Apache mods & conf (logs should be forwarded to stdout & stderr for docker; ServerName fqdn)

--- a/legacy/Dockerfile
+++ b/legacy/Dockerfile
@@ -19,6 +19,7 @@ RUN set -eux; apt update -q && \
     memcached libmemcached-tools php-cli php-memcached php8.3-memcached \
     php-mysql default-mysql-client \
     php8.3-bcmath php8.3-curl php8.3-dom php8.3-mbstring php8.3-intl \
+    php8.3-xdebug \
     sendmail libphp-phpmailer php-mail && \
   apt purge -yq patch software-properties-common && \
   apt autoremove -yqq && \

--- a/legacy/docker-compose.yml
+++ b/legacy/docker-compose.yml
@@ -32,5 +32,18 @@ services:
         target: /etc/php/8.3/apache2/php.ini
         bind:
           create_host_path: true
+      - type: bind
+        source: ./docker-local/php-xdebug-docker.ini
+        target: /etc/php/8.3/apache2/conf.d/21-xdebug-docker.ini
+        bind:
+          create_host_path: true
+      - type: bind
+        source: ./docker-local/php-xdebug-docker.ini
+        target: /etc/php/8.3/cli/conf.d/21-xdebug-docker.ini
+        bind:
+          create_host_path: true
     networks:
       - aula_local
+    extra_hosts:
+      # for resolution on Linux
+      - "host.docker.internal:host-gateway"

--- a/legacy/docker-local/php-xdebug-docker.ini
+++ b/legacy/docker-local/php-xdebug-docker.ini
@@ -1,3 +1,4 @@
+zend_extension=xdebug.so
 ; enable step debugging
 xdebug.mode=develop,debug
 xdebug.start_with_request=yes

--- a/legacy/docker-local/php-xdebug-docker.ini
+++ b/legacy/docker-local/php-xdebug-docker.ini
@@ -1,0 +1,5 @@
+; enable step debugging
+xdebug.mode=develop,debug
+xdebug.start_with_request=yes
+; provided to Linux by docker-compose extra_hosts
+xdebug.client_host=host.docker.internal


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Adding you all as reviewers since it ungitignores `.vscode`.

<!-- Example:
After the last update it became apparent that we did fetch the new results, but didn't actually store them properly. This caused a glitch in the UI whenever the user would refresh the page.
-->

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
