### PR TITLE
add user level enum for v2

### DIFF
--- a/app/Console/Commands/AddUserToTenant.php
+++ b/app/Console/Commands/AddUserToTenant.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Enums\UserLevel;
 use App\Models\Tenant;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
@@ -14,19 +15,6 @@ class AddUserToTenant extends Command
     protected $signature = 'tenant:add-user';
 
     protected $description = 'Add a user to a tenant instance';
-
-    private const ROLES = [
-        10 => 'Guest',
-        20 => 'User',
-        30 => 'Moderator',
-        31 => 'Moderator+',
-        40 => 'Super Moderator',
-        41 => 'Super Moderator+',
-        44 => 'Principal',
-        45 => 'Principal+',
-        50 => 'Admin',
-        60 => 'Tech Admin',
-    ];
 
     public function handle(): int
     {
@@ -75,17 +63,25 @@ class AddUserToTenant extends Command
         }
 
         // Select role
-        $roleChoices = array_map(
-            fn ($level, $name) => "{$name} ({$level})",
-            array_keys(self::ROLES),
-            array_values(self::ROLES)
+        $roleChoices = collect(UserLevel::cases())
+            ->mapWithKeys(fn (UserLevel $level) => [
+                "{$level->label()} ({$level->value})" => $level,
+            ])
+            ->all();
+        $defaultRoleChoice = array_search(
+            UserLevel::Admin->label().' ('.UserLevel::Admin->value.')',
+            array_keys($roleChoices),
+            true
         );
 
-        $selectedRole = $this->choice('Select role', $roleChoices, 8); // Default: Admin (50)
+        $selectedRole = $this->choice(
+            'Select role',
+            array_keys($roleChoices),
+            $defaultRoleChoice
+        );
 
-        preg_match('/\((\d+)\)$/', $selectedRole, $matches);
-        $userlevel = (int) $matches[1];
-        $roleName = self::ROLES[$userlevel];
+        $userlevel = $roleChoices[$selectedRole];
+        $roleName = $userlevel->label();
 
         // Ask for password
         $password = $this->secret('Password');
@@ -114,7 +110,7 @@ class AddUserToTenant extends Command
                 ['Username', $username],
                 ['Full Name', $fullName],
                 ['Email', $email],
-                ['Role', "{$roleName} ({$userlevel})"],
+                ['Role', "{$roleName} ({$userlevel->value})"],
             ]
         );
 
@@ -147,7 +143,7 @@ class AddUserToTenant extends Command
                     'hash_id' => Str::random(32),
                     'registration_status' => 2,
                     'status' => 1,
-                    'userlevel' => $userlevel,
+                    'userlevel' => $userlevel->value,
                     'created' => $now,
                     'last_update' => $now,
                     'pw_changed' => 1,

--- a/app/Console/Commands/AddUserToTenant.php
+++ b/app/Console/Commands/AddUserToTenant.php
@@ -63,16 +63,8 @@ class AddUserToTenant extends Command
         }
 
         // Select role
-        $roleChoices = collect(UserLevel::cases())
-            ->mapWithKeys(fn (UserLevel $level) => [
-                "{$level->label()} ({$level->value})" => $level,
-            ])
-            ->all();
-        $defaultRoleChoice = array_search(
-            UserLevel::Admin->label().' ('.UserLevel::Admin->value.')',
-            array_keys($roleChoices),
-            true
-        );
+        $roleChoices = $this->roleChoices();
+        $defaultRoleChoice = $this->roleChoiceIndex(UserLevel::Admin, $roleChoices);
 
         $selectedRole = $this->choice(
             'Select role',
@@ -160,5 +152,30 @@ class AddUserToTenant extends Command
         $this->info("User '{$username}' created successfully as {$roleName}.");
 
         return self::SUCCESS;
+    }
+
+    private function roleChoices(): array
+    {
+        return collect(UserLevel::cases())
+            ->mapWithKeys(fn (UserLevel $level) => [
+                $this->roleChoiceLabel($level) => $level,
+            ])
+            ->all();
+    }
+
+    private function roleChoiceIndex(UserLevel $level, array $roleChoices): int
+    {
+        $index = array_search($this->roleChoiceLabel($level), array_keys($roleChoices), true);
+
+        if ($index === false) {
+            throw new \RuntimeException("Role choice for '{$level->value}' was not found.");
+        }
+
+        return $index;
+    }
+
+    private function roleChoiceLabel(UserLevel $level): string
+    {
+        return "{$level->label()} ({$level->value})";
     }
 }

--- a/app/Console/Commands/ListTenants.php
+++ b/app/Console/Commands/ListTenants.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Enums\UserLevel;
 use App\Models\Tenant;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
@@ -46,7 +47,7 @@ class ListTenants extends Command
             try {
                 $admins = $tenant->run(function () {
                     return DB::table('au_users_basedata')
-                        ->where('userlevel', '>=', 50)
+                        ->where('userlevel', '>=', UserLevel::Admin->value)
                         ->orderBy('userlevel', 'desc')
                         ->orderBy('id')
                         ->get(['id', 'username', 'realname', 'email', 'userlevel', 'status']);
@@ -56,11 +57,7 @@ class ListTenants extends Command
                     $this->line('  No admin users found.');
                 } else {
                     $rows = $admins->map(function ($admin) {
-                        $level = match ($admin->userlevel) {
-                            60 => 'Tech Admin',
-                            50 => 'Admin',
-                            default => "Level {$admin->userlevel}",
-                        };
+                        $level = UserLevel::labelFor((int) $admin->userlevel);
 
                         $status = match ($admin->status) {
                             0 => 'Inactive',

--- a/app/Enums/UserLevel.php
+++ b/app/Enums/UserLevel.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum UserLevel: int
+{
+    case Guest = 10;
+    case User = 20;
+    case Moderator = 30;
+    case ModeratorPlus = 31;
+    case SuperModerator = 40;
+    case SuperModeratorPlus = 41;
+    case Principal = 44;
+    case PrincipalPlus = 45;
+    case Admin = 50;
+    case TechAdmin = 60;
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Guest => 'Guest',
+            self::User => 'User',
+            self::Moderator => 'Moderator',
+            self::ModeratorPlus => 'Moderator+',
+            self::SuperModerator => 'Super Moderator',
+            self::SuperModeratorPlus => 'Super Moderator+',
+            self::Principal => 'Principal',
+            self::PrincipalPlus => 'Principal+',
+            self::Admin => 'Admin',
+            self::TechAdmin => 'Tech Admin',
+        };
+    }
+
+    public static function labelFor(int $value): string
+    {
+        return self::tryFrom($value)?->label() ?? "Level {$value}";
+    }
+}

--- a/app/Models/LegacyUser.php
+++ b/app/Models/LegacyUser.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\UserLevel;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Model;
 
@@ -37,7 +38,7 @@ class LegacyUser extends Model implements Authenticatable
      */
     protected $casts = [
         'id' => 'integer',
-        'userlevel' => 'integer',
+        'userlevel' => UserLevel::class,
         'status' => 'integer',
         'refresh_token' => 'boolean',
         'created' => 'datetime',
@@ -92,7 +93,7 @@ class LegacyUser extends Model implements Authenticatable
         return [
             'id' => $this->id,
             'hash_id' => $this->hash_id,
-            'userlevel' => $this->userlevel,
+            'userlevel' => $this->userlevel?->value,
             'roles' => $this->roles,
             'temp_pw' => !empty($this->temp_pw),
         ];

--- a/app/Services/LegacyJwtService.php
+++ b/app/Services/LegacyJwtService.php
@@ -24,7 +24,7 @@ class LegacyJwtService
             'exp' => 0,
             'user_id' => $user->id,
             'user_hash' => $user->hash_id,
-            'user_level' => $user->userlevel,
+            'user_level' => $user->userlevel?->value,
             'roles' => json_decode($user->roles ?? '[]'),
             'temp_pw' => !empty($user->temp_pw),
         ];

--- a/app/UseCases/CreateTenantUseCase.php
+++ b/app/UseCases/CreateTenantUseCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\UseCases;
 
+use App\Enums\UserLevel;
 use App\Models\Tenant;
 use App\Services\TenantsService;
 use Illuminate\Support\Facades\DB;
@@ -112,7 +113,7 @@ class CreateTenantUseCase
             'hash_id' => Str::random(32),
             'registration_status' => 2,
             'status' => 1,
-            'userlevel' => 50,
+            'userlevel' => UserLevel::Admin->value,
             'created' => $now,
             'last_update' => $now,
             'pw_changed' => $pwChanged,

--- a/routes/tenant/api/v2/auth.php
+++ b/routes/tenant/api/v2/auth.php
@@ -29,7 +29,7 @@ Route::middleware('legacy.jwt')->group(function () {
             'email' => $user->email,
             'displayname' => $user->displayname,
             'realname' => $user->realname,
-            'userlevel' => $user->userlevel,
+            'userlevel' => $user->userlevel?->value,
             'roles' => json_decode($user->roles ?? '[]'),
         ]);
     })->name('me');

--- a/tests/Feature/LegacyAuthTest.php
+++ b/tests/Feature/LegacyAuthTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Feature;
 
+use App\Enums\UserLevel;
 use App\Models\LegacyUser;
 use App\Services\LegacyJwtService;
+use Illuminate\Support\Facades\DB;
 use Tests\Concerns\CreatesTestTenant;
 use Tests\TestCase;
 
@@ -30,7 +32,7 @@ class LegacyAuthTest extends TestCase
         $user = new LegacyUser();
         $user->id = 1;
         $user->hash_id = 'test_hash_123';
-        $user->userlevel = 20;
+        $user->userlevel = UserLevel::User;
         $user->roles = json_encode([]);
         $user->temp_pw = null;
 
@@ -103,7 +105,7 @@ class LegacyAuthTest extends TestCase
         $user = new LegacyUser();
         $user->id = 42;
         $user->hash_id = 'hash_abc';
-        $user->userlevel = 30;
+        $user->userlevel = UserLevel::Moderator;
         $user->roles = json_encode([['room' => 'room1', 'role' => 30]]);
         $user->temp_pw = null;
 
@@ -133,7 +135,7 @@ class LegacyAuthTest extends TestCase
             $user->pw = password_hash($password, PASSWORD_DEFAULT);
             $user->status = LegacyUser::STATUS_ACTIVE;
             $user->hash_id = 'phpunit_hash_' . uniqid();
-            $user->userlevel = 20;
+            $user->userlevel = UserLevel::User;
             $user->roles = json_encode([]);
             $user->refresh_token = false;
             $user->save();
@@ -155,12 +157,51 @@ class LegacyAuthTest extends TestCase
         $this->assertCount(3, $parts);
 
         $payload = json_decode(base64_decode($parts[1]), true);
-        $this->assertEquals(20, $payload['user_level']);
+        $this->assertEquals(UserLevel::User->value, $payload['user_level']);
         $this->assertFalse($payload['temp_pw']);
 
         $tenant->run(function () {
             LegacyUser::where('username', 'phpunit_testuser')->delete();
         });
+    }
+
+    public function test_legacy_userlevel_persists_as_integer_in_tenant_database(): void
+    {
+        $tenant = self::$testTenant;
+        $this->assertNotNull($tenant);
+
+        $result = $tenant->run(function () {
+            LegacyUser::where('username', 'phpunit_enum_user')->delete();
+
+            $user = new LegacyUser();
+            $user->username = 'phpunit_enum_user';
+            $user->pw = password_hash('secret123', PASSWORD_DEFAULT);
+            $user->status = LegacyUser::STATUS_ACTIVE;
+            $user->hash_id = 'phpunit_enum_'.uniqid();
+            $user->userlevel = UserLevel::PrincipalPlus;
+            $user->roles = json_encode([]);
+            $user->refresh_token = false;
+            $user->save();
+
+            $userId = $user->id;
+            $rawUserLevel = DB::table('au_users_basedata')
+                ->where('id', $userId)
+                ->value('userlevel');
+
+            $freshUser = LegacyUser::findOrFail($userId);
+
+            LegacyUser::where('id', $userId)->delete();
+
+            return [
+                'raw' => (int) $rawUserLevel,
+                'casted_class' => get_class($freshUser->userlevel),
+                'casted_value' => $freshUser->userlevel->value,
+            ];
+        });
+
+        $this->assertSame(45, $result['raw']);
+        $this->assertSame(UserLevel::class, $result['casted_class']);
+        $this->assertSame(UserLevel::PrincipalPlus->value, $result['casted_value']);
     }
 
     public function test_login_wrong_password(): void
@@ -176,7 +217,7 @@ class LegacyAuthTest extends TestCase
             $user->pw = password_hash('correctpass', PASSWORD_DEFAULT);
             $user->status = LegacyUser::STATUS_ACTIVE;
             $user->hash_id = 'phpunit_hash_' . uniqid();
-            $user->userlevel = 20;
+            $user->userlevel = UserLevel::User;
             $user->roles = json_encode([]);
             $user->refresh_token = false;
             $user->save();
@@ -226,7 +267,7 @@ class LegacyAuthTest extends TestCase
             $user->pw = password_hash('testpass', PASSWORD_DEFAULT);
             $user->status = LegacyUser::STATUS_SUSPENDED;
             $user->hash_id = 'phpunit_hash_' . uniqid();
-            $user->userlevel = 20;
+            $user->userlevel = UserLevel::User;
             $user->roles = json_encode([]);
             $user->refresh_token = false;
             $user->save();
@@ -261,7 +302,7 @@ class LegacyAuthTest extends TestCase
         $user = new LegacyUser();
         $user->id = 1;
         $user->hash_id = 'hash123';
-        $user->userlevel = 20;
+        $user->userlevel = UserLevel::User;
         $user->roles = json_encode([['room' => 'abc', 'role' => 20]]);
         $user->temp_pw = '';
 
@@ -284,6 +325,6 @@ class LegacyAuthTest extends TestCase
         $this->assertEquals(0, $payload['exp']);
         $this->assertEquals(1, $payload['user_id']);
         $this->assertEquals('hash123', $payload['user_hash']);
-        $this->assertEquals(20, $payload['user_level']);
+        $this->assertEquals(UserLevel::User->value, $payload['user_level']);
     }
 }

--- a/tests/Feature/LegacyAuthTest.php
+++ b/tests/Feature/LegacyAuthTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature;
 use App\Enums\UserLevel;
 use App\Models\LegacyUser;
 use App\Services\LegacyJwtService;
-use Illuminate\Support\Facades\DB;
 use Tests\Concerns\CreatesTestTenant;
 use Tests\TestCase;
 
@@ -163,45 +162,6 @@ class LegacyAuthTest extends TestCase
         $tenant->run(function () {
             LegacyUser::where('username', 'phpunit_testuser')->delete();
         });
-    }
-
-    public function test_legacy_userlevel_persists_as_integer_in_tenant_database(): void
-    {
-        $tenant = self::$testTenant;
-        $this->assertNotNull($tenant);
-
-        $result = $tenant->run(function () {
-            LegacyUser::where('username', 'phpunit_enum_user')->delete();
-
-            $user = new LegacyUser();
-            $user->username = 'phpunit_enum_user';
-            $user->pw = password_hash('secret123', PASSWORD_DEFAULT);
-            $user->status = LegacyUser::STATUS_ACTIVE;
-            $user->hash_id = 'phpunit_enum_'.uniqid();
-            $user->userlevel = UserLevel::PrincipalPlus;
-            $user->roles = json_encode([]);
-            $user->refresh_token = false;
-            $user->save();
-
-            $userId = $user->id;
-            $rawUserLevel = DB::table('au_users_basedata')
-                ->where('id', $userId)
-                ->value('userlevel');
-
-            $freshUser = LegacyUser::findOrFail($userId);
-
-            LegacyUser::where('id', $userId)->delete();
-
-            return [
-                'raw' => (int) $rawUserLevel,
-                'casted_class' => get_class($freshUser->userlevel),
-                'casted_value' => $freshUser->userlevel->value,
-            ];
-        });
-
-        $this->assertSame(45, $result['raw']);
-        $this->assertSame(UserLevel::class, $result['casted_class']);
-        $this->assertSame(UserLevel::PrincipalPlus->value, $result['casted_value']);
     }
 
     public function test_login_wrong_password(): void

--- a/tests/Feature/Models/LegacyUserTest.php
+++ b/tests/Feature/Models/LegacyUserTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Enums\UserLevel;
+use App\Models\LegacyUser;
+use Illuminate\Support\Facades\DB;
+use Tests\Concerns\CreatesTestTenant;
+use Tests\TestCase;
+
+class LegacyUserTest extends TestCase
+{
+    use CreatesTestTenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->ensureTestTenantExists();
+    }
+
+    public function test_userlevel_persists_as_integer_and_is_cast_back_to_enum(): void
+    {
+        $tenant = self::$testTenant;
+        $this->assertNotNull($tenant);
+
+        $result = $tenant->run(function () {
+            LegacyUser::where('username', 'phpunit_enum_user')->delete();
+
+            $user = new LegacyUser();
+            $user->username = 'phpunit_enum_user';
+            $user->pw = password_hash('secret123', PASSWORD_DEFAULT);
+            $user->status = LegacyUser::STATUS_ACTIVE;
+            $user->hash_id = 'phpunit_enum_'.uniqid();
+            $user->userlevel = UserLevel::PrincipalPlus;
+            $user->roles = json_encode([]);
+            $user->refresh_token = false;
+            $user->save();
+
+            $userId = $user->id;
+            $rawUserLevel = DB::table('au_users_basedata')
+                ->where('id', $userId)
+                ->value('userlevel');
+
+            $freshUser = LegacyUser::findOrFail($userId);
+
+            LegacyUser::where('id', $userId)->delete();
+
+            return [
+                'raw' => (int) $rawUserLevel,
+                'casted' => $freshUser->userlevel,
+            ];
+        });
+
+        $this->assertSame(UserLevel::PrincipalPlus->value, $result['raw']);
+        $this->assertSame(UserLevel::PrincipalPlus, $result['casted']);
+    }
+}

--- a/tests/Unit/LegacyJwtServiceTest.php
+++ b/tests/Unit/LegacyJwtServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use App\Enums\UserLevel;
 use App\Models\LegacyUser;
 use App\Services\LegacyJwtService;
 use Mockery;
@@ -39,7 +40,7 @@ class LegacyJwtServiceTest extends TestCase
         $user->hash_id = $attributes['hash_id'] ?? 'abc123def456';
         $user->username = $attributes['username'] ?? 'testuser';
         $user->email = $attributes['email'] ?? 'test@example.com';
-        $user->userlevel = $attributes['userlevel'] ?? 20;
+        $user->userlevel = $attributes['userlevel'] ?? UserLevel::User;
         $user->roles = $attributes['roles'] ?? json_encode([['room' => 'room1', 'role' => 20]]);
         $user->status = $attributes['status'] ?? LegacyUser::STATUS_ACTIVE;
         $user->temp_pw = $attributes['temp_pw'] ?? null;
@@ -79,7 +80,7 @@ class LegacyJwtServiceTest extends TestCase
         $user = $this->createMockUser([
             'id' => 42,
             'hash_id' => 'unique_hash_123',
-            'userlevel' => 30,
+            'userlevel' => UserLevel::Moderator,
             'roles' => json_encode([['room' => 'test_room', 'role' => 30]]),
         ]);
 
@@ -214,7 +215,7 @@ class LegacyJwtServiceTest extends TestCase
         $user = $this->createMockUser([
             'id' => 1,
             'hash_id' => 'test_hash',
-            'userlevel' => 20,
+            'userlevel' => UserLevel::User,
             'roles' => '[]',
         ]);
 

--- a/tests/Unit/LegacyUserUserLevelTest.php
+++ b/tests/Unit/LegacyUserUserLevelTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Enums\UserLevel;
+use App\Models\LegacyUser;
+use Tests\TestCase;
+
+class LegacyUserUserLevelTest extends TestCase
+{
+    public function test_it_casts_userlevel_to_enum_and_keeps_jwt_payload_integer(): void
+    {
+        $user = new LegacyUser();
+        $user->userlevel = UserLevel::Moderator;
+
+        $this->assertInstanceOf(UserLevel::class, $user->userlevel);
+        $this->assertSame(UserLevel::Moderator, $user->userlevel);
+        $this->assertSame(UserLevel::Moderator->value, $user->getJwtPayload()['userlevel']);
+    }
+}

--- a/tests/Unit/LegacyUserUserLevelTest.php
+++ b/tests/Unit/LegacyUserUserLevelTest.php
@@ -13,8 +13,6 @@ class LegacyUserUserLevelTest extends TestCase
         $user = new LegacyUser();
         $user->userlevel = UserLevel::Moderator;
 
-        $this->assertInstanceOf(UserLevel::class, $user->userlevel);
-        $this->assertSame(UserLevel::Moderator, $user->userlevel);
         $this->assertSame(UserLevel::Moderator->value, $user->getJwtPayload()['userlevel']);
     }
 }


### PR DESCRIPTION
## Context

Refactors v2 `userlevel` handling to use a PHP backed enum instead of raw integers in the Laravel layer.

This keeps the external and persistence contract unchanged:
- `userlevel` is still stored in the database as an integer
- JWT/API payloads still expose integer values
- command/test code now uses enum cases instead of scattered magic numbers

This also replaces the hardcoded role map in `AddUserToTenant` with the enum-based source of truth.

Closes #478

## Checklist

- [x] Tested manually
- [x] GitHub issue linked
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases)
- [x] Doesn't need update in the database
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula))