### PR TITLE
fix: new tenants can't be used due to permission issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 # v2
 
+- fix: new tenants can't be used due to permission issue
+
 ## v2.1.0
 
 - feat: aula Manager using Filament

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,7 @@ ENV APP_VERSION=$DOCKER_TAG
 
 # Copy everything (respects .dockerignore)
 COPY . .
+# Reown by www-data and make sure setgid bit is on for storage, so
+#   any new folders created in ./storage will inherit the group www-data
 RUN chown -R www-data:www-data ./ \
-    && chmod -R 755 ./storage
+    && chmod -R u=rwx,g=rws,o=rx ./storage

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,6 +24,9 @@ echo "✅ Database is ready."
 php artisan migrate --force
 php artisan optimize:clear
 php artisan storage:link
+# Make sure write and setgid bits is enabled for storage, so
+#   any new folders created in ./storage will inherit the group www-data
+chmod -R g+ws ./storage
 
 echo "🔑 Ensuring Passport keys are present and with correct permissions..."
 php artisan passport:keys -q


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Since we sometimes create new Tenants from cli, using php artisan tenant:create, this will create ./storage/tenant_$UUID/ folder as root.

The fix is setting the ./storage/ folder have a setgid bit, so that regardless of the user executing mkdir ./storage/*, the children folders will inherit the parent group ownership (ignoring the process owner: root).

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
