### PR TITLE
Feat/tenant export import clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - feat: aula Manager using Filament
 - fix: stop re-generating app key for encrypting JWT/sessions on app startup
 - fix: logging permissions
+- feat: add tenant:export and tenant:import commands
 
 ## v2.0.3
 

--- a/app/Console/Commands/ExportTenant.php
+++ b/app/Console/Commands/ExportTenant.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Tenant;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Process;
+
+class ExportTenant extends Command
+{
+    protected $signature = 'tenant:export
+                            {--code= : Instance code of the tenant to export}
+                            {--id= : UUID of the tenant to export}
+                            {--output= : Output file path (default: tenant_CODE_DATETIME.tar.gz in current directory)}';
+
+    protected $description = 'Export a tenant\'s central DB row and database dump to a tar.gz archive';
+
+    public function handle(): int
+    {
+        $tenant = $this->resolveTenant();
+        if ($tenant === null) {
+            return self::FAILURE;
+        }
+
+        $this->info("Exporting tenant: {$tenant->name} (code: {$tenant->instance_code})");
+
+        $dbName = $tenant->tenancy_db_name ?? null;
+        if ($dbName === null) {
+            $this->error('Tenant database name not found (tenancy_db_name missing).');
+
+            return self::FAILURE;
+        }
+
+        $outputFile = $this->option('output')
+            ?? getcwd().'/tenant_'.$tenant->instance_code.'_'.now()->format('Ymd_His').'.tar.gz';
+
+        $tmpDir = sys_get_temp_dir().'/tenant_export_'.uniqid();
+        mkdir($tmpDir, 0700, true);
+
+        try {
+            file_put_contents(
+                "{$tmpDir}/tenant.json",
+                json_encode($tenant->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+            );
+
+            $this->info("Dumping database: {$dbName}");
+
+            $host = config('database.connections.mariadb.host');
+            $port = (string) config('database.connections.mariadb.port');
+            $user = config('database.connections.mariadb.username');
+            $pass = (string) config('database.connections.mariadb.password');
+
+            $result = Process::env(['MYSQL_PWD' => $pass])->run([
+                'mysqldump',
+                "--host={$host}",
+                "--port={$port}",
+                "--user={$user}",
+                '--single-transaction',
+                '--routines',
+                '--triggers',
+                '--result-file='.$tmpDir.'/tenant.sql',
+                $dbName,
+            ]);
+
+            if (! $result->successful()) {
+                $this->error('mysqldump failed:');
+                $this->line($result->errorOutput());
+
+                return self::FAILURE;
+            }
+
+            $result = Process::run([
+                'tar', '-czf', $outputFile,
+                '-C', $tmpDir,
+                'tenant.json', 'tenant.sql',
+            ]);
+
+            if (! $result->successful()) {
+                $this->error('Failed to create archive:');
+                $this->line($result->errorOutput());
+
+                return self::FAILURE;
+            }
+
+            $this->info("Export complete: {$outputFile}");
+
+            return self::SUCCESS;
+        } finally {
+            Process::run(['rm', '-rf', $tmpDir]);
+        }
+    }
+
+    private function resolveTenant(): ?Tenant
+    {
+        $code = $this->option('code');
+        $id = $this->option('id');
+
+        if ($code === null && $id === null) {
+            $this->error('Provide --code or --id to identify the tenant.');
+
+            return null;
+        }
+
+        $tenant = $code
+            ? Tenant::firstWhere('instance_code', $code)
+            : Tenant::find($id);
+
+        if ($tenant === null) {
+            $this->error('Tenant not found.');
+
+            return null;
+        }
+
+        return $tenant;
+    }
+}

--- a/app/Console/Commands/ExportTenant.php
+++ b/app/Console/Commands/ExportTenant.php
@@ -71,10 +71,21 @@ class ExportTenant extends Command
                 return self::FAILURE;
             }
 
+            $grants = implode(', ', [
+                'ALTER', 'ALTER ROUTINE', 'CREATE', 'CREATE ROUTINE', 'CREATE TEMPORARY TABLES', 'CREATE VIEW',
+                'DELETE', 'DROP', 'EVENT', 'EXECUTE', 'INDEX', 'INSERT', 'LOCK TABLES', 'REFERENCES', 'SELECT',
+                'SHOW VIEW', 'TRIGGER', 'UPDATE',
+            ]);
+            file_put_contents("{$tmpDir}/setup.sql", implode("\n", [
+                "CREATE DATABASE `{{DB_NAME}}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;",
+                "CREATE USER `{{DB_USER}}`@`%` IDENTIFIED BY '{{DB_PASS}}';",
+                "GRANT {$grants} ON `{{DB_NAME}}`.* TO `{{DB_USER}}`@`%`;",
+            ]));
+
             $result = Process::run([
                 'tar', '-czf', $outputFile,
                 '-C', $tmpDir,
-                'tenant.json', 'tenant.sql',
+                'tenant.json', 'tenant.sql', 'setup.sql',
             ]);
 
             if (! $result->successful()) {

--- a/app/Console/Commands/ExportTenant.php
+++ b/app/Console/Commands/ExportTenant.php
@@ -71,6 +71,7 @@ class ExportTenant extends Command
                 return self::FAILURE;
             }
 
+            // Should match docker/mariadb/950_init-user-privileges.sh
             $grants = implode(', ', [
                 'ALTER', 'ALTER ROUTINE', 'CREATE', 'CREATE ROUTINE', 'CREATE TEMPORARY TABLES', 'CREATE VIEW',
                 'DELETE', 'DROP', 'EVENT', 'EXECUTE', 'INDEX', 'INSERT', 'LOCK TABLES', 'REFERENCES', 'SELECT',

--- a/app/Console/Commands/ImportTenant.php
+++ b/app/Console/Commands/ImportTenant.php
@@ -121,17 +121,22 @@ class ImportTenant extends Command
             $tenant->admin2_username = $exported['admin2_username'] ?? null;
             $tenant->admin2_email = $exported['admin2_email'] ?? null;
             $tenant->admin2_init_pass_url = null;
-            $tenant->data = [
-                'tenancy_db_name' => $dbName,
-                'tenancy_db_username' => $dbUser,
-                'tenancy_db_password' => $dbPass,
-            ];
+            $tenant->setInternal('db_name', $dbName);
+            $tenant->setInternal('db_username', $dbUser);
+            $tenant->setInternal('db_password', $dbPass);
             $tenant->save();
         });
 
         $this->info("Creating database: {$dbName}");
 
         DB::statement("CREATE DATABASE `{$dbName}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+        $grants = implode(', ', [
+            'ALTER', 'ALTER ROUTINE', 'CREATE', 'CREATE ROUTINE', 'CREATE TEMPORARY TABLES', 'CREATE VIEW',
+            'DELETE', 'DROP', 'EVENT', 'EXECUTE', 'INDEX', 'INSERT', 'LOCK TABLES', 'REFERENCES', 'SELECT',
+            'SHOW VIEW', 'TRIGGER', 'UPDATE',
+        ]);
+        DB::statement("CREATE USER `{$dbUser}`@`%` IDENTIFIED BY '{$dbPass}'");
+        DB::statement("GRANT {$grants} ON `{$dbName}`.* TO `{$dbUser}`@`%`");
 
         $this->info('Importing database dump...');
 

--- a/app/Console/Commands/ImportTenant.php
+++ b/app/Console/Commands/ImportTenant.php
@@ -50,8 +50,8 @@ class ImportTenant extends Command
             return self::FAILURE;
         }
 
-        if (! file_exists("{$tmpDir}/tenant.json") || ! file_exists("{$tmpDir}/tenant.sql")) {
-            $this->error('Archive is missing tenant.json or tenant.sql.');
+        if (! file_exists("{$tmpDir}/tenant.json") || ! file_exists("{$tmpDir}/tenant.sql") || ! file_exists("{$tmpDir}/setup.sql")) {
+            $this->error('Archive is missing tenant.json, tenant.sql, or setup.sql.');
 
             return self::FAILURE;
         }
@@ -129,14 +129,7 @@ class ImportTenant extends Command
 
         $this->info("Creating database: {$dbName}");
 
-        DB::statement("CREATE DATABASE `{$dbName}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
-        $grants = implode(', ', [
-            'ALTER', 'ALTER ROUTINE', 'CREATE', 'CREATE ROUTINE', 'CREATE TEMPORARY TABLES', 'CREATE VIEW',
-            'DELETE', 'DROP', 'EVENT', 'EXECUTE', 'INDEX', 'INSERT', 'LOCK TABLES', 'REFERENCES', 'SELECT',
-            'SHOW VIEW', 'TRIGGER', 'UPDATE',
-        ]);
-        DB::statement("CREATE USER `{$dbUser}`@`%` IDENTIFIED BY '{$dbPass}'");
-        DB::statement("GRANT {$grants} ON `{$dbName}`.* TO `{$dbUser}`@`%`");
+        $this->executeSetupSql($tmpDir, $dbName, $dbUser, $dbPass);
 
         $this->info('Importing database dump...');
 
@@ -170,5 +163,17 @@ class ImportTenant extends Command
         $this->line("  Database:      {$dbName}");
 
         return self::SUCCESS;
+    }
+
+    private function executeSetupSql(string $tmpDir, string $dbName, string $dbUser, string $dbPass): void
+    {
+        $sql = str_replace(
+            ['{{DB_NAME}}', '{{DB_USER}}', '{{DB_PASS}}'],
+            [$dbName, $dbUser, $dbPass],
+            file_get_contents("{$tmpDir}/setup.sql")
+        );
+        foreach (array_filter(array_map('trim', explode(";\n", $sql))) as $statement) {
+            DB::statement($statement);
+        }
     }
 }

--- a/app/Console/Commands/ImportTenant.php
+++ b/app/Console/Commands/ImportTenant.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Tenant;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Str;
+
+class ImportTenant extends Command
+{
+    protected $signature = 'tenant:import
+                            {file : Path to the .tar.gz export file produced by tenant:export}
+                            {--code= : Override the instance code from the export (must be 5 alphanumeric chars or SINGLE)}
+                            {--name= : Override the tenant name from the export}
+                            {--force : Skip the confirmation prompt}';
+
+    protected $description = 'Import a tenant from a tar.gz archive produced by tenant:export';
+
+    public function handle(): int
+    {
+        $file = $this->argument('file');
+
+        if (! file_exists($file)) {
+            $this->error("File not found: {$file}");
+
+            return self::FAILURE;
+        }
+
+        $tmpDir = sys_get_temp_dir().'/tenant_import_'.uniqid();
+        mkdir($tmpDir, 0700, true);
+
+        try {
+            return $this->doImport($file, $tmpDir);
+        } finally {
+            Process::run(['rm', '-rf', $tmpDir]);
+        }
+    }
+
+    private function doImport(string $file, string $tmpDir): int
+    {
+        $result = Process::run(['tar', '-xzf', $file, '-C', $tmpDir]);
+        if (! $result->successful()) {
+            $this->error('Failed to extract archive:');
+            $this->line($result->errorOutput());
+
+            return self::FAILURE;
+        }
+
+        if (! file_exists("{$tmpDir}/tenant.json") || ! file_exists("{$tmpDir}/tenant.sql")) {
+            $this->error('Archive is missing tenant.json or tenant.sql.');
+
+            return self::FAILURE;
+        }
+
+        $exported = json_decode(file_get_contents("{$tmpDir}/tenant.json"), true);
+        if ($exported === null) {
+            $this->error('tenant.json is not valid JSON.');
+
+            return self::FAILURE;
+        }
+
+        $instanceCode = $this->option('code') ?? $exported['instance_code'];
+        $tenantName = $this->option('name') ?? $exported['name'];
+
+        if (! preg_match('/^[0-9a-zA-Z]{5}$|^SINGLE$/', $instanceCode)) {
+            $this->error('Instance code must be exactly 5 alphanumeric characters, or SINGLE.');
+
+            return self::FAILURE;
+        }
+
+        if (Tenant::firstWhere('instance_code', $instanceCode) !== null) {
+            $this->error("A tenant with instance code '{$instanceCode}' already exists on this server.");
+
+            return self::FAILURE;
+        }
+
+        if (Tenant::firstWhere('name', $tenantName) !== null) {
+            $this->error("A tenant named '{$tenantName}' already exists on this server. Use --name to override.");
+
+            return self::FAILURE;
+        }
+
+        $this->info('=== Tenant to import ===');
+        $this->table(['Field', 'Value'], [
+            ['Name', $tenantName],
+            ['Instance code', $instanceCode],
+            ['Original code', $exported['instance_code']],
+            ['Original ID', $exported['id']],
+        ]);
+
+        if (! $this->option('force') && ! $this->confirm('Proceed with import?', true)) {
+            $this->warn('Import cancelled.');
+
+            return self::SUCCESS;
+        }
+
+        $tenantId = Str::uuid()->toString();
+        $dbName = 'tenant_'.$tenantId;
+        $dbUser = 'aula_'.$instanceCode;
+        $dbPass = Str::random(63);
+
+        $this->info('Creating tenant record...');
+
+        Tenant::withoutEvents(function () use ($exported, $tenantId, $instanceCode, $tenantName, $dbName, $dbUser, $dbPass) {
+            $tenant = new Tenant;
+            $tenant->id = $tenantId;
+            $tenant->name = $tenantName;
+            $tenant->api_base_url = config('app.url');
+            $tenant->contact_info = $exported['contact_info'] ?? null;
+            $tenant->instance_code = $instanceCode;
+            $tenant->jwt_key = $exported['jwt_key'];
+            $tenant->admin1_name = $exported['admin1_name'] ?? null;
+            $tenant->admin1_username = $exported['admin1_username'] ?? null;
+            $tenant->admin1_email = $exported['admin1_email'] ?? null;
+            $tenant->admin1_init_pass_url = null;
+            $tenant->admin2_name = $exported['admin2_name'] ?? null;
+            $tenant->admin2_username = $exported['admin2_username'] ?? null;
+            $tenant->admin2_email = $exported['admin2_email'] ?? null;
+            $tenant->admin2_init_pass_url = null;
+            $tenant->data = [
+                'tenancy_db_name' => $dbName,
+                'tenancy_db_username' => $dbUser,
+                'tenancy_db_password' => $dbPass,
+            ];
+            $tenant->save();
+        });
+
+        $this->info("Creating database: {$dbName}");
+
+        DB::statement("CREATE DATABASE `{$dbName}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
+
+        $this->info('Importing database dump...');
+
+        $host = config('database.connections.mariadb.host');
+        $port = (string) config('database.connections.mariadb.port');
+        $user = config('database.connections.mariadb.username');
+        $pass = (string) config('database.connections.mariadb.password');
+
+        $result = Process::env(['MYSQL_PWD' => $pass])->input(
+            file_get_contents("{$tmpDir}/tenant.sql")
+        )->run([
+            'mysql',
+            "--host={$host}",
+            "--port={$port}",
+            "--user={$user}",
+            $dbName,
+        ]);
+
+        if (! $result->successful()) {
+            $this->error('mysql import failed:');
+            $this->line($result->errorOutput());
+            $this->warn('Tenant record and database were created but data import failed. Clean up manually.');
+
+            return self::FAILURE;
+        }
+
+        $this->newLine();
+        $this->info("Tenant '{$tenantName}' imported successfully.");
+        $this->line("  ID:            {$tenantId}");
+        $this->line("  Instance code: {$instanceCode}");
+        $this->line("  Database:      {$dbName}");
+
+        return self::SUCCESS;
+    }
+}

--- a/docker/mariadb/950_init-user-privileges.sh
+++ b/docker/mariadb/950_init-user-privileges.sh
@@ -9,6 +9,8 @@
 # The default $MARIADB_USER only gets access to $MARIADB_DATABASE while
 # stancl/tenancy library needs to CREATE/DROP databases and CREATE/DROP users for them dynamically.
 #
+# Should match app/Console/Commands/ExportTenant.php
+#
 mariadb -u root -p"${MARIADB_ROOT_PASSWORD}" <<-EOSQL
     GRANT USAGE, ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE TEMPORARY TABLES, CREATE USER, CREATE VIEW, DELETE, DROP, EVENT, EXECUTE, INDEX, INSERT, LOCK TABLES, REFERENCES, SELECT, SHOW VIEW, TRIGGER, UPDATE ON *.* TO '${MARIADB_USER}'@'%' WITH GRANT OPTION;
     FLUSH PRIVILEGES;

--- a/tests/Feature/ExportTenantCommandTest.php
+++ b/tests/Feature/ExportTenantCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Tenant;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Str;
+
+uses(DatabaseTransactions::class);
+
+function createTenantForExport(array $attrs = []): Tenant
+{
+    // withoutEvents prevents stancl from running CreateDatabase (DDL that commits the transaction)
+    return Tenant::withoutEvents(function () use ($attrs) {
+        $tenant = new Tenant(array_merge([
+            'name'            => 'Export School',
+            'instance_code'   => 'EXP01',
+            'jwt_key'         => 'testkey',
+            'api_base_url'    => 'https://example.com',
+            'admin1_name'     => 'Admin One',
+            'admin1_username' => 'admin1',
+            'admin1_email'    => 'admin1@test.com',
+            'admin2_name'     => 'Admin Two',
+            'admin2_username' => 'admin2',
+            'admin2_email'    => 'admin2@test.com',
+            'tenancy_db_name' => 'tenant_test_export',
+        ], $attrs));
+        $tenant->id = (string) Str::uuid();
+        $tenant->save();
+
+        return $tenant;
+    });
+}
+
+it('fails when neither --code nor --id is provided', function () {
+    $this->artisan('tenant:export')->assertFailed();
+});
+
+it('fails when tenant is not found by code', function () {
+    $this->artisan('tenant:export', ['--code' => 'XXXXX'])->assertFailed();
+});
+
+it('fails when tenant is not found by id', function () {
+    $this->artisan('tenant:export', ['--id' => '00000000-0000-0000-0000-000000000000'])->assertFailed();
+});
+
+it('exports successfully by code', function () {
+    createTenantForExport();
+
+    Process::fake([
+        "'mysqldump'*" => Process::result(),
+        "'tar'*"       => Process::result(),
+        "'rm'*"        => Process::result(),
+    ]);
+
+    $this->artisan('tenant:export', [
+        '--code'   => 'EXP01',
+        '--output' => '/tmp/test_export_code.tar.gz',
+    ])->assertSuccessful();
+});
+
+it('exports successfully by id', function () {
+    $tenant = createTenantForExport();
+
+    Process::fake([
+        "'mysqldump'*" => Process::result(),
+        "'tar'*"       => Process::result(),
+        "'rm'*"        => Process::result(),
+    ]);
+
+    $this->artisan('tenant:export', [
+        '--id'     => $tenant->id,
+        '--output' => '/tmp/test_export_id.tar.gz',
+    ])->assertSuccessful();
+});
+
+it('fails when mysqldump fails', function () {
+    createTenantForExport();
+
+    Process::fake([
+        "'mysqldump'*" => Process::result('', 'Connection refused', 1),
+        "'rm'*"        => Process::result(),
+    ]);
+
+    $this->artisan('tenant:export', ['--code' => 'EXP01'])->assertFailed();
+});
+
+it('fails when tar fails', function () {
+    createTenantForExport();
+
+    Process::fake([
+        "'mysqldump'*" => Process::result(),
+        "'tar'*"       => Process::result('', 'No space left on device', 1),
+        "'rm'*"        => Process::result(),
+    ]);
+
+    $this->artisan('tenant:export', ['--code' => 'EXP01'])->assertFailed();
+});

--- a/tests/Feature/ImportTenantCommandTest.php
+++ b/tests/Feature/ImportTenantCommandTest.php
@@ -27,9 +27,14 @@ function makeTenantArchive(array $overrides = []): string
     mkdir($dir, 0700, true);
     file_put_contents("{$dir}/tenant.json", json_encode($data, JSON_UNESCAPED_UNICODE));
     file_put_contents("{$dir}/tenant.sql", '-- empty');
+    file_put_contents("{$dir}/setup.sql", implode("\n", [
+        "CREATE DATABASE `{{DB_NAME}}` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;",
+        "CREATE USER `{{DB_USER}}`@`%` IDENTIFIED BY '{{DB_PASS}}';",
+        "GRANT SELECT ON `{{DB_NAME}}`.* TO `{{DB_USER}}`@`%`;",
+    ]));
 
     $archive = sys_get_temp_dir().'/test_import_'.uniqid().'.tar.gz';
-    exec("tar -czf {$archive} -C {$dir} tenant.json tenant.sql");
+    exec("tar -czf {$archive} -C {$dir} tenant.json tenant.sql setup.sql");
     exec("rm -rf {$dir}");
 
     return $archive;

--- a/tests/Feature/ImportTenantCommandTest.php
+++ b/tests/Feature/ImportTenantCommandTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Tenant;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Str;
+
+uses(DatabaseTransactions::class);
+
+function makeTenantArchive(array $overrides = []): string
+{
+    $data = array_merge([
+        'id'              => '00000000-0000-0000-0000-000000000001',
+        'name'            => 'Import School',
+        'instance_code'   => 'IMP01',
+        'jwt_key'         => 'testkey',
+        'contact_info'    => null,
+        'admin1_name'     => 'Admin One',
+        'admin1_username' => 'admin1',
+        'admin1_email'    => 'admin1@test.com',
+        'admin2_name'     => 'Admin Two',
+        'admin2_username' => 'admin2',
+        'admin2_email'    => 'admin2@test.com',
+    ], $overrides);
+
+    $dir = sys_get_temp_dir().'/test_import_src_'.uniqid();
+    mkdir($dir, 0700, true);
+    file_put_contents("{$dir}/tenant.json", json_encode($data, JSON_UNESCAPED_UNICODE));
+    file_put_contents("{$dir}/tenant.sql", '-- empty');
+
+    $archive = sys_get_temp_dir().'/test_import_'.uniqid().'.tar.gz';
+    exec("tar -czf {$archive} -C {$dir} tenant.json tenant.sql");
+    exec("rm -rf {$dir}");
+
+    return $archive;
+}
+
+function createTenantForImportTest(array $attrs = []): Tenant
+{
+    // withoutEvents prevents stancl from running CreateDatabase (DDL that commits the transaction)
+    return Tenant::withoutEvents(function () use ($attrs) {
+        $tenant = new Tenant($attrs);
+        $tenant->id = (string) Str::uuid();
+        $tenant->save();
+
+        return $tenant;
+    });
+}
+
+function mockCreateDatabase(): void
+{
+    // Intercept CREATE DATABASE so it doesn't commit the transaction via DDL implicit commit
+    $db = DB::partialMock();
+    $db->shouldReceive('statement')
+        ->withArgs(fn (string $sql) => str_contains($sql, 'CREATE DATABASE'))
+        ->andReturn(true);
+}
+
+it('fails when the archive file does not exist', function () {
+    $this->artisan('tenant:import', ['file' => '/tmp/nonexistent_archive.tar.gz'])->assertFailed();
+});
+
+it('fails when instance code format is invalid', function () {
+    $archive = makeTenantArchive(['instance_code' => 'BAD!CODE']);
+
+    $this->artisan('tenant:import', ['file' => $archive, '--force' => true])->assertFailed();
+
+    unlink($archive);
+});
+
+it('fails when a tenant with the same instance code already exists', function () {
+    createTenantForImportTest([
+        'name'            => 'Existing School',
+        'instance_code'   => 'IMP01',
+        'jwt_key'         => 'key',
+        'api_base_url'    => 'https://example.com',
+        'admin1_name'     => 'Admin One',
+        'admin1_username' => 'admin1',
+        'admin1_email'    => 'admin1@test.com',
+        'admin2_name'     => 'Admin Two',
+        'admin2_username' => 'admin2',
+        'admin2_email'    => 'admin2@test.com',
+    ]);
+
+    $archive = makeTenantArchive();
+
+    $this->artisan('tenant:import', ['file' => $archive, '--force' => true])->assertFailed();
+
+    unlink($archive);
+});
+
+it('fails when a tenant with the same name already exists', function () {
+    createTenantForImportTest([
+        'name'            => 'Import School',
+        'instance_code'   => 'OTH01',
+        'jwt_key'         => 'key',
+        'api_base_url'    => 'https://example.com',
+        'admin1_name'     => 'Admin One',
+        'admin1_username' => 'admin1',
+        'admin1_email'    => 'admin1@test.com',
+        'admin2_name'     => 'Admin Two',
+        'admin2_username' => 'admin2',
+        'admin2_email'    => 'admin2@test.com',
+    ]);
+
+    $archive = makeTenantArchive();
+
+    $this->artisan('tenant:import', ['file' => $archive, '--force' => true])->assertFailed();
+
+    unlink($archive);
+});
+
+it('imports a tenant successfully', function () {
+    $archive = makeTenantArchive();
+
+    mockCreateDatabase();
+    Process::fake(["'mysql'*" => Process::result()]);
+
+    $this->artisan('tenant:import', ['file' => $archive, '--force' => true])->assertSuccessful();
+
+    expect(Tenant::firstWhere('instance_code', 'IMP01'))->not->toBeNull();
+
+    unlink($archive);
+});
+
+it('accepts SINGLE as a valid instance code', function () {
+    $archive = makeTenantArchive(['instance_code' => 'SINGLE', 'name' => 'Single School']);
+
+    mockCreateDatabase();
+    Process::fake(["'mysql'*" => Process::result()]);
+
+    $this->artisan('tenant:import', ['file' => $archive, '--force' => true])->assertSuccessful();
+
+    unlink($archive);
+});
+
+it('overrides instance code and name via options', function () {
+    $archive = makeTenantArchive();
+
+    mockCreateDatabase();
+    Process::fake(["'mysql'*" => Process::result()]);
+
+    $this->artisan('tenant:import', [
+        'file'    => $archive,
+        '--code'  => 'OVR01',
+        '--name'  => 'Overridden School',
+        '--force' => true,
+    ])->assertSuccessful();
+
+    expect(Tenant::firstWhere('instance_code', 'OVR01'))->not->toBeNull();
+
+    unlink($archive);
+});
+
+it('fails when mysql import fails', function () {
+    $archive = makeTenantArchive(['instance_code' => 'FAIL1', 'name' => 'Fail School']);
+
+    mockCreateDatabase();
+    Process::fake(["'mysql'*" => Process::result('', 'Access denied', 1)]);
+
+    $this->artisan('tenant:import', ['file' => $archive, '--force' => true])->assertFailed();
+
+    unlink($archive);
+});

--- a/tests/Feature/ImportTenantCommandTest.php
+++ b/tests/Feature/ImportTenantCommandTest.php
@@ -52,11 +52,8 @@ function createTenantForImportTest(array $attrs = []): Tenant
 
 function mockCreateDatabase(): void
 {
-    // Intercept CREATE DATABASE so it doesn't commit the transaction via DDL implicit commit
-    $db = DB::partialMock();
-    $db->shouldReceive('statement')
-        ->withArgs(fn (string $sql) => str_contains($sql, 'CREATE DATABASE'))
-        ->andReturn(true);
+    // Intercept all raw statements (DDL causes implicit commits that break DatabaseTransactions)
+    DB::partialMock()->shouldReceive('statement')->andReturn(true);
 }
 
 it('fails when the archive file does not exist', function () {

--- a/tests/Feature/ImportTenantCommandTest.php
+++ b/tests/Feature/ImportTenantCommandTest.php
@@ -3,12 +3,9 @@
 declare(strict_types=1);
 
 use App\Models\Tenant;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Str;
-
-uses(DatabaseTransactions::class);
 
 function makeTenantArchive(array $overrides = []): string
 {
@@ -40,7 +37,6 @@ function makeTenantArchive(array $overrides = []): string
 
 function createTenantForImportTest(array $attrs = []): Tenant
 {
-    // withoutEvents prevents stancl from running CreateDatabase (DDL that commits the transaction)
     return Tenant::withoutEvents(function () use ($attrs) {
         $tenant = new Tenant($attrs);
         $tenant->id = (string) Str::uuid();
@@ -50,10 +46,24 @@ function createTenantForImportTest(array $attrs = []): Tenant
     });
 }
 
-function mockCreateDatabase(): void
+function cleanupImportedTenant(string $instanceCode): void
 {
-    // Intercept all raw statements (DDL causes implicit commits that break DatabaseTransactions)
-    DB::partialMock()->shouldReceive('statement')->andReturn(true);
+    $tenant = Tenant::firstWhere('instance_code', $instanceCode);
+    if (! $tenant) {
+        return;
+    }
+
+    $dbName  = $tenant->getInternal('db_name');
+    $dbUser  = $tenant->getInternal('db_username');
+
+    if ($dbName) {
+        DB::statement("DROP DATABASE IF EXISTS `{$dbName}`");
+    }
+    if ($dbUser) {
+        DB::statement("DROP USER IF EXISTS `{$dbUser}`@`%`");
+    }
+
+    $tenant->withoutEvents(fn () => $tenant->forceDelete());
 }
 
 it('fails when the archive file does not exist', function () {
@@ -69,7 +79,7 @@ it('fails when instance code format is invalid', function () {
 });
 
 it('fails when a tenant with the same instance code already exists', function () {
-    createTenantForImportTest([
+    $tenant = createTenantForImportTest([
         'name'            => 'Existing School',
         'instance_code'   => 'IMP01',
         'jwt_key'         => 'key',
@@ -87,10 +97,11 @@ it('fails when a tenant with the same instance code already exists', function ()
     $this->artisan('tenant:import', ['file' => $archive, '--force' => true])->assertFailed();
 
     unlink($archive);
+    $tenant->withoutEvents(fn () => $tenant->forceDelete());
 });
 
 it('fails when a tenant with the same name already exists', function () {
-    createTenantForImportTest([
+    $tenant = createTenantForImportTest([
         'name'            => 'Import School',
         'instance_code'   => 'OTH01',
         'jwt_key'         => 'key',
@@ -108,36 +119,53 @@ it('fails when a tenant with the same name already exists', function () {
     $this->artisan('tenant:import', ['file' => $archive, '--force' => true])->assertFailed();
 
     unlink($archive);
+    $tenant->withoutEvents(fn () => $tenant->forceDelete());
 });
 
-it('imports a tenant successfully', function () {
+it('imports a tenant and creates the database and user', function () {
     $archive = makeTenantArchive();
 
-    mockCreateDatabase();
     Process::fake(["'mysql'*" => Process::result()]);
 
     $this->artisan('tenant:import', ['file' => $archive, '--force' => true])->assertSuccessful();
 
-    expect(Tenant::firstWhere('instance_code', 'IMP01'))->not->toBeNull();
+    $tenant = Tenant::firstWhere('instance_code', 'IMP01');
+    expect($tenant)->not->toBeNull();
+
+    $dbName = $tenant->getInternal('db_name');
+    $dbUser = $tenant->getInternal('db_username');
+    $dbPass = $tenant->getInternal('db_password');
+
+    expect($dbName)->not->toBeNull();
+    expect($dbUser)->toBe('aula_IMP01');
+    expect($dbPass)->not->toBeNull();
+
+    $databases = DB::select("SHOW DATABASES LIKE '{$dbName}'");
+    expect($databases)->not->toBeEmpty();
+
+    $userExists = DB::select("SELECT COUNT(*) as cnt FROM mysql.user WHERE user = '{$dbUser}'")[0]->cnt;
+    expect($userExists)->toBe(1);
 
     unlink($archive);
+    cleanupImportedTenant('IMP01');
 });
 
 it('accepts SINGLE as a valid instance code', function () {
     $archive = makeTenantArchive(['instance_code' => 'SINGLE', 'name' => 'Single School']);
 
-    mockCreateDatabase();
     Process::fake(["'mysql'*" => Process::result()]);
 
     $this->artisan('tenant:import', ['file' => $archive, '--force' => true])->assertSuccessful();
 
+    expect(Tenant::firstWhere('instance_code', 'SINGLE'))->not->toBeNull();
+
     unlink($archive);
+    cleanupImportedTenant('SINGLE');
 });
 
 it('overrides instance code and name via options', function () {
     $archive = makeTenantArchive();
 
-    mockCreateDatabase();
     Process::fake(["'mysql'*" => Process::result()]);
 
     $this->artisan('tenant:import', [
@@ -150,15 +178,16 @@ it('overrides instance code and name via options', function () {
     expect(Tenant::firstWhere('instance_code', 'OVR01'))->not->toBeNull();
 
     unlink($archive);
+    cleanupImportedTenant('OVR01');
 });
 
 it('fails when mysql import fails', function () {
     $archive = makeTenantArchive(['instance_code' => 'FAIL1', 'name' => 'Fail School']);
 
-    mockCreateDatabase();
     Process::fake(["'mysql'*" => Process::result('', 'Access denied', 1)]);
 
     $this->artisan('tenant:import', ['file' => $archive, '--force' => true])->assertFailed();
 
     unlink($archive);
+    cleanupImportedTenant('FAIL1');
 });


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Fix https://github.com/aula-app/aula-manager/issues/42

A tenant can be now exported with: php artisan tenant:export --code 
This generates a .tar.gz file containing a json with the instance details and a sql for the instance database.

The tenant can be import with:  php artisan tenant:import --code=NEW-CODE --name=NEW-NAME ./tenant_INSTANCE_CODE_20260430_141745.tar.gz

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
