### PR TITLE
Add same permissions for super users with voting rights to remove Idea Likes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ## v2.1.1
 
-- fix: super_moderator_v role permission on IdeaRemoveLike
+- fix: super_moderator_v role permissions on IdeaRemoveLike, CommentAddLike and CommentRemoveLike
 - fix: new tenants can't be used due to permission issue
 
 ## v2.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 # v2
 
+## v2.1.1
+
+- fix: super_moderator_v role permission on IdeaRemoveLike
+
 ## v2.1.0
 
 - feat: aula Manager using Filament

--- a/legacy/src/classes/helpers/Permissions.php
+++ b/legacy/src/classes/helpers/Permissions.php
@@ -105,6 +105,7 @@ function checkPermissions($db, $crypt, $syslog, $model_name, $method, $arguments
         ],
         "roles" => [
           "user",
+          "moderator_v"
           # "moderator" - excluded because it doesn't have voting rights
           # "principal" - excluded because it doesn't have voting rights
           # "super_moderator" - excluded because it doesn't have voting rights
@@ -125,6 +126,7 @@ function checkPermissions($db, $crypt, $syslog, $model_name, $method, $arguments
         ],
         "roles" => [
           "user",
+          "moderator_v"
         ],
         "from_room" => [
           "get_room" => "comment_id",

--- a/legacy/src/classes/helpers/Permissions.php
+++ b/legacy/src/classes/helpers/Permissions.php
@@ -105,7 +105,6 @@ function checkPermissions($db, $crypt, $syslog, $model_name, $method, $arguments
         ],
         "roles" => [
           "user",
-          "moderator_v"
           # "moderator" - excluded because it doesn't have voting rights
           # "principal" - excluded because it doesn't have voting rights
           # "super_moderator" - excluded because it doesn't have voting rights
@@ -120,16 +119,12 @@ function checkPermissions($db, $crypt, $syslog, $model_name, $method, $arguments
 
       "CommentRemoveLike" => [
         "open_roles" => [
-          "super_moderator",
           "super_moderator_v",
-          "principal",
           "principal_v",
           "admin"
         ],
         "roles" => [
           "user",
-          "moderator",
-          "moderator_v"
         ],
         "from_room" => [
           "get_room" => "comment_id",

--- a/legacy/src/classes/helpers/Permissions.php
+++ b/legacy/src/classes/helpers/Permissions.php
@@ -1047,15 +1047,14 @@ function checkPermissions($db, $crypt, $syslog, $model_name, $method, $arguments
         ],
 
         "IdeaRemoveLike" => [
-          "roles" => [
-            "user",
-            "moderator",
-            "moderator_v",
-            "super_moderator",
+          "open_roles" => [
             "super_moderator_v",
-            "principal",
             "principal_v",
             "admin"
+          ],
+          "roles" => [
+            "user",
+            "moderator_v",
           ],
           "from_room" => [
             "get_room" => "idea_id"


### PR DESCRIPTION
super moderator with voting rights can remove their likes with the need to check if they belong to the room.
 
Fix #484 

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
