### PR TITLE
Remove persistent connections from mariadb legacy connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - fix: super_moderator_v role permissions on IdeaRemoveLike, CommentAddLike and CommentRemoveLike
 - fix: new tenants can't be used due to permission issue
+- fix: remove mariadb persistent connections from legacy connector
 
 ## v2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 
 - fix: super_moderator_v role permissions on IdeaRemoveLike, CommentAddLike and CommentRemoveLike
 - fix: new tenants can't be used due to permission issue
-- fix: remove mariadb persistent connections from legacy connector
 
 ## v2.1.0
 
@@ -38,6 +37,9 @@
 
 ##
 
+## v1.9.4
+
+- fix: remove mariadb persistent connections from legacy connector
 - fix(upload): backup/restore of uploaded files by creating instance folder with 0770 perms
 
 ## v1.9.3

--- a/legacy/src/classes/models/Database.php
+++ b/legacy/src/classes/models/Database.php
@@ -51,7 +51,6 @@
         // Set up a PDO connection
         $dsn = "mysql:host=$this->host;port=$this->port;dbname=$this->dbname";
         $options = array(
-            PDO::ATTR_PERSISTENT => true,
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
         );
         try {


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

<!-- Example:
After the last update it became apparent that we did fetch the new results, but didn't actually store them properly. This caused a glitch in the UI whenever the user would refresh the page.
-->

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [x] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
