### PR TITLE
fix DB port for running `make test` out-of-the-box

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ run-legacy-release:
 	docker compose -f ./legacy/docker-compose.yml up -d
 
 test:
+	docker compose -f docker-compose.test.yml down
 	docker compose -f docker-compose.test.yml up --build --abort-on-container-exit --exit-code-from app-test
 
 # Simplistic tasks that mirror the scans in .github/workflows/pr-vuln-scan.yml

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -26,6 +26,8 @@ services:
     environment:
       DB_HOST: mariadb-test
       CENTRAL_DB_HOST: mariadb-test
+      DB_PORT: 3306
+      CENTRAL_DB_PORT: 3306
     depends_on:
       mariadb-test:
         condition: service_healthy


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Reviewing https://github.com/aula-app/aula-backend/pull/464 I wanted to run the tests, but `make test` would break over a connection error. I assume you are running tests with a local mariadb.

I could not get the mariadb service to run on the expected 3307... so this is now even more "overwrite the .env file".

Open question: any subsequent `make test` will fail because "tenant exists", because the DB is not flushed. Instead it requires a `docker compose down` or other manual cleanup. Fix, document?
Same thing happens when I run tests which use the dev DB, what's the workflow there? 

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
