### PR TITLE
'owner' key must be a array in permissions table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 # v2
 
+## v2.1.2
+
+ - fix: non super users can't add or remove categories from an idea (#507)
+
 ## v2.1.1
 
 - fix: super_moderator_v role permissions on IdeaRemoveLike, CommentAddLike and CommentRemoveLike

--- a/legacy/src/classes/helpers/Permissions.php
+++ b/legacy/src/classes/helpers/Permissions.php
@@ -965,7 +965,7 @@ function checkPermissions($db, $crypt, $syslog, $model_name, $method, $arguments
             "moderator",
             "moderator_v"
           ],
-          "owner" => "idea_id"
+          "owner" => [ "idea_id" ]
         ],
 
         "IdeaAddLike" => [
@@ -1070,7 +1070,7 @@ function checkPermissions($db, $crypt, $syslog, $model_name, $method, $arguments
             "admin",
             "owner"
           ],
-          "owner" => "idea_id"
+          "owner" => [ "idea_id" ]
         ],
 
         "getIdeasByRoom" => [


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Closes #507 

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
- [x] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
