### PR TITLE
chore: update PR template: v1 <-> v2

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,6 @@ After the last update it became apparent that we did fetch the new results, but 
 - [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
 - [ ] Changelist updated
 - [ ] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
-- [ ] Doesn't need update in the database <!-- If it does, please describe how to deploy it without downtime -->
+- [ ] Independent of the other BE version (v1 <-> v2) <!-- If it isn't, please describe how to deploy them together without downtime -->
 - [ ] Must be deployed ASAP (HOTFIX)
 - [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

After merging of @aivuk's https://github.com/aula-app/aula-backend/pull/464, @nikola-maric-aula deployed BE v1 to dev, but it stopped working with Users, as noted by @leonard-haas in https://github.com/aula-app/aula-backend/issues/484#issuecomment-4590661124. The reason is that v1 was deployed independently of v2, and our DB migration scripts are in v2.

<img width="269" alt="image" src="https://github.com/user-attachments/assets/7b060f39-30de-4c0b-8154-e2f0d7edeeff" />


With the introduction of DB migrations tool, the PR template should change. We don't need to do manual DB intervention anymore, but we need to carefully sync deployments of BE v1 and v2.