### PR TITLE
fix: run tenancy db migrations; fix: ensure ./storage folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,7 @@
 ## v2.2.0
 
 - feat: add SSO login via Keycloak
-
-## v2.1.2
-
- - fix: non super users can't add or remove categories from an idea (#507)
+- fix: run tenancy DB migrations on deployment
 
 ## v2.1.1
 
@@ -43,6 +40,8 @@
 # v1
 
 ##
+
+- fix: non super users can't add or remove categories from an idea (#507)
 
 ## v1.9.5
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,6 +8,10 @@ php artisan clear-compiled
 
 echo "🔑 Checking app key for encryption (sessions, JWT, app-level encryption)..."
 if ! grep -q '^APP_KEY=' .env || grep -q '^APP_KEY=$' .env; then
+  # Ensure framework cache and other folders are available
+  mkdir -p storage/app/private storage/app/public storage/framework/cache storage/framework/sessions storage/framework/testing storage/framework/views
+  chown -R www-data:www-data ./storage
+
   echo "🔑 No existing key found. Generating new app key..."
   php artisan key:generate --force
   echo "✅ App key generated."
@@ -22,6 +26,7 @@ done
 echo "✅ Database is ready."
 
 php artisan migrate --force
+php artisan tenants:migrate --force
 php artisan optimize:clear
 php artisan storage:link
 # Make sure write and setgid bits is enabled for storage, so


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

We weren't running tenancy db migrations on startup. Also for the first-time deployment to new infra, we should ensure ./storage folder has its structure and ownership as expected.

See also:
- https://github.com/aula-app/aula-backend/pull/523

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [x] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [x] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Independent of the other BE version (v1 <-> v2) <!-- If it isn't, please describe how to deploy them together without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
