### PR TITLE
fix: add missing app.frontend_url config

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -53,6 +53,7 @@ return [
     */
 
     'url' => env('APP_URL', 'http://localhost'),
+    'frontend_url' => env('APP_FRONTEND_URL', config('app.url') ?? 'http://localhost:3000'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

I built this manually locally and pushed to staging and i could pass the login through SSO.

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [/] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [/] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Independent of the other BE version (v1 <-> v2) <!-- If it isn't, please describe how to deploy them together without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
