### PR TITLE
work around psalm findUnusedBaselineEntry bug

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0"?>
+<!--
+  findUnusedBaselineEntry: is buggy, can create an invalid SARIF file that trips up CI/GH
+  (contains `"startLine":0,"endLine":0,"startColumn":0,"endColumn":0`)
+  set to true when https://github.com/vimeo/psalm/issues/9712 is fixed
+-->
 <psalm
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="https://getpsalm.org/schema/config"
@@ -7,6 +12,7 @@
   findUnusedCode="false"
   ensureOverrideAttribute="false"
   errorBaseline="psalm-baseline.xml"
+  findUnusedBaselineEntry="false"
 >
   <projectFiles>
     <directory name="."/>


### PR DESCRIPTION
## Context #529, part 2.

work around psalm bug

## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Independent of the other BE version (v1 <-> v2) <!-- If it isn't, please describe how to deploy them together without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
