### PR TITLE
Fix/v2 gate before type guard

### DIFF
--- a/app/Providers/AuthzServiceProvider.php
+++ b/app/Providers/AuthzServiceProvider.php
@@ -18,7 +18,17 @@ class AuthzServiceProvider extends ServiceProvider
             ]);
         });
 
-        Gate::before(function (LegacyUser $user): bool|null {
+        // Runs for *every* gate check in the application, not just the API v2
+        // ones defined here. The Filament manager panel authenticates
+        // AulaManagerUser on the `web` guard and reaches these callbacks
+        // directly (filament/helpers.php invades Gate::callBeforeCallbacks),
+        // so a LegacyUser type hint 500s every /manager route. Narrow inside
+        // the closure instead, and fall through for anything else.
+        Gate::before(function (mixed $user, string $ability): bool|null {
+            if (!$user instanceof LegacyUser) {
+                return null;
+            }
+
             return $user->isAdmin() ? true : null;
         });
 

--- a/app/Providers/AuthzServiceProvider.php
+++ b/app/Providers/AuthzServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace App\Providers;
 
-use App\Enums\UserLevel;
 use App\Models\LegacyUser;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Gate;
@@ -11,11 +10,14 @@ class AuthzServiceProvider extends ServiceProvider
 {
     public function boot(): void
     {
+        // TODO(v1 divergence): isAdmin() covers Admin *and* TechAdmin, but
+        // legacy's Permissions.php grants "admin" in ~100 rule entries and
+        // "tech_admin" in only ~20 -- userlevel is not a hierarchy there. As
+        // long as Gate::before below bypasses everything for both, TechAdmin
+        // gains abilities in v2 that it does not have in v1. Needs a product
+        // decision before this covers more than the User resource.
         Gate::define('admin', function (LegacyUser $user) {
-            return \in_array($user->userlevel, [
-                UserLevel::Admin,
-                UserLevel::TechAdmin,
-            ]);
+            return $user->isAdmin();
         });
 
         // Runs for *every* gate check in the application, not just the API v2


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

This assures that the filament user (AulaManagerUser) access is still working. 

# Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [ ] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [ ] Independent of the other BE version (v1 <-> v2) <!-- If it isn't, please describe how to deploy them together without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
