### PR TITLE
Fix/v2 user self update escalation

### DIFF
--- a/app/Providers/AuthzServiceProvider.php
+++ b/app/Providers/AuthzServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Data\User\Requests\UpdateUserData;
 use App\Enums\UserLevel;
 use App\Models\LegacyUser;
 use Illuminate\Support\ServiceProvider;
@@ -38,8 +39,22 @@ class AuthzServiceProvider extends ServiceProvider
             return false;
         });
 
-        Gate::define('update-users', function (LegacyUser $user, string $publicId) {
-            return $user->hash_id === $publicId;
+        // Takes the loaded row rather than a public id, because the rule is not
+        // only "who" but "which fields": a user may edit their own record, but
+        // never the fields that grant access. Admins bypass via Gate::before
+        // and so never reach this closure.
+        //
+        // PUT makes the client send every field, so an unprivileged caller has
+        // to echo back the current userlevel/status. Only an actual change is
+        // an escalation attempt.
+        Gate::define('update-users', function (
+            LegacyUser $user,
+            LegacyUser $subject,
+            UpdateUserData $userUpdateData,
+        ) {
+            return $user->hash_id === $subject->hash_id
+                && $userUpdateData->userLevel === $subject->userlevel
+                && $userUpdateData->status === $subject->status;
         });
 
         Gate::define('destroy-users', function () {

--- a/app/UseCases/User/UpdateUserUseCase.php
+++ b/app/UseCases/User/UpdateUserUseCase.php
@@ -13,17 +13,19 @@ class UpdateUserUseCase
 {
     public function execute(string $hashId, UpdateUserData $userUpdateData): DomainUserData
     {
-        Gate::authorize('update-users', $hashId);
-        // Gate::authorize('user-self', $publicId);
-
         /* TODO: DB::transaction */
+        // Loaded before the check: the rule depends on the row's current
+        // userlevel/status, not just on the id.
         $legacyUser = LegacyUser::where('hash_id', $hashId)->firstOrFail();
+
+        Gate::authorize('update-users', [$legacyUser, $userUpdateData]);
 
         $legacyUser->displayname = $userUpdateData->displayName;
         $legacyUser->realname = $userUpdateData->realName;
         $legacyUser->username = $userUpdateData->userName;
         $legacyUser->email = $userUpdateData->email;
         $legacyUser->userlevel = $userUpdateData->userLevel;
+        $legacyUser->status = $userUpdateData->status;
         $legacyUser->about_me = $userUpdateData->aboutMe;
         $legacyUser->save();
         /* / DB::transaction */

--- a/tests/Feature/CrudUserTest.php
+++ b/tests/Feature/CrudUserTest.php
@@ -73,6 +73,48 @@ class CrudUserTest extends TestCase
         });
     }
 
+    /**
+     * Unlike createUserIfNotExists(), this always inserts a fresh row, so tests
+     * that mutate their subject can't clobber each other's fixtures.
+     */
+    private function createDistinctUser(UserLevel $userLevel, UserStatus $userStatus): LegacyUser
+    {
+        return self::$testTenant->run(function () use ($userLevel, $userStatus) {
+            $email = 'e2e_distinct_' . bin2hex(random_bytes(8)) . '@aula.de';
+            $user = new LegacyUser();
+            $user->email         = $email;
+            $user->displayname   = 'Distinct';
+            $user->realname      = 'Distinct User';
+            $user->about_me      = 'About me.';
+            $user->sso_sub       = null;
+            $user->status        = $userStatus;
+            $user->username      = $email;
+            $user->hash_id       = md5($email);
+            $user->userlevel     = $userLevel;
+            $user->roles         = json_encode([]);
+            $user->refresh_token = false;
+            $user->save();
+            return $user;
+        });
+    }
+
+    /**
+     * A full PUT body echoing the user's current state, so individual tests can
+     * override just the field under test.
+     */
+    private function putBodyFor(LegacyUser $user): array
+    {
+        return [
+            'displayname' => $user->displayname,
+            'username' => $user->username,
+            'realname' => $user->realname,
+            'status' => $user->status->value,
+            'email' => $user->email,
+            'userlevel' => $user->userlevel->value,
+            'about_me' => $user->about_me,
+        ];
+    }
+
     private function jwtForUser(LegacyUser $user): string
     {
         return self::$testTenant->run(
@@ -121,6 +163,68 @@ class CrudUserTest extends TestCase
             ['Authorization' => "Bearer {$jwt}"]
         )
             ->assertForbidden();
+    }
+
+    public function test_authz_self_update_cannot_escalate_userlevel()
+    {
+        $user = $this->createDistinctUser(UserLevel::User, UserStatus::Active);
+        $jwt = $this->jwtForUser($user);
+
+        $this->putJson(
+            "/api/v2/users/{$user->hash_id}",
+            [...$this->putBodyFor($user), 'userlevel' => UserLevel::TechAdmin->value],
+            ['Authorization' => "Bearer {$jwt}"]
+        )
+            ->assertForbidden();
+
+        $this->assertSame(
+            UserLevel::User,
+            self::$testTenant->run(fn () => LegacyUser::where('hash_id', $user->hash_id)->sole()->userlevel)
+        );
+    }
+
+    public function test_authz_self_update_cannot_change_status()
+    {
+        $user = $this->createDistinctUser(UserLevel::User, UserStatus::Active);
+        $jwt = $this->jwtForUser($user);
+
+        $this->putJson(
+            "/api/v2/users/{$user->hash_id}",
+            [...$this->putBodyFor($user), 'status' => UserStatus::Suspended->value],
+            ['Authorization' => "Bearer {$jwt}"]
+        )
+            ->assertForbidden();
+    }
+
+    public function test_authz_self_update_allows_own_profile_fields()
+    {
+        $user = $this->createDistinctUser(UserLevel::User, UserStatus::Active);
+        $jwt = $this->jwtForUser($user);
+
+        $this->putJson(
+            "/api/v2/users/{$user->hash_id}",
+            [...$this->putBodyFor($user), 'realname' => 'Renamed Self'],
+            ['Authorization' => "Bearer {$jwt}"]
+        )
+            ->assertOk()
+            ->assertJson(['realname' => 'Renamed Self', 'userlevel' => UserLevel::User->value]);
+    }
+
+    public function test_admin_update_may_change_userlevel_and_status()
+    {
+        $user = $this->createDistinctUser(UserLevel::User, UserStatus::Active);
+
+        // setUp() installs admin credentials as the default headers
+        $this->putJson("/api/v2/users/{$user->hash_id}", [
+            ...$this->putBodyFor($user),
+            'userlevel' => UserLevel::Moderator->value,
+            'status' => UserStatus::Suspended->value,
+        ])
+            ->assertOk()
+            ->assertJson([
+                'userlevel' => UserLevel::Moderator->value,
+                'status' => UserStatus::Suspended->value,
+            ]);
     }
 
     public function test_authz_inactive()


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

Just allow admin to change userlevel.

## Checklist

- [ ] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [ ] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [ ] Independent of the other BE version (v1 <-> v2) <!-- If it isn't, please describe how to deploy them together without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
