### PR TITLE
fix: build keycloak with health enabled; docs: update docker instructions

### DIFF
--- a/keycloak/idp-error-authenticator/Dockerfile
+++ b/keycloak/idp-error-authenticator/Dockerfile
@@ -14,10 +14,11 @@ FROM maven:3.9-eclipse-temurin-17 AS build
 WORKDIR /build
 COPY pom.xml .
 COPY src ./src
+ENV KC_HEALTH_ENABLED=true
 RUN mvn -B -q clean package
 
 # ---- Stage 2: Keycloak image with the provider ----
-FROM quay.io/keycloak/keycloak:26.6.1
+FROM quay.io/keycloak/keycloak:26.5.5
 COPY --from=build /build/target/aula-idp-error-authenticator.jar /opt/keycloak/providers/
 # Augment the server at build time so the container starts pre-built and immutable.
 # Bake the build-time options that match the runtime env (KC_DB, KC_HTTP_RELATIVE_PATH)

--- a/keycloak/idp-error-authenticator/Dockerfile
+++ b/keycloak/idp-error-authenticator/Dockerfile
@@ -18,7 +18,7 @@ ENV KC_HEALTH_ENABLED=true
 RUN mvn -B -q clean package
 
 # ---- Stage 2: Keycloak image with the provider ----
-FROM quay.io/keycloak/keycloak:26.5.5
+FROM quay.io/keycloak/keycloak:26.6.1
 COPY --from=build /build/target/aula-idp-error-authenticator.jar /opt/keycloak/providers/
 # Augment the server at build time so the container starts pre-built and immutable.
 # Bake the build-time options that match the runtime env (KC_DB, KC_HTTP_RELATIVE_PATH)

--- a/keycloak/idp-error-authenticator/README.md
+++ b/keycloak/idp-error-authenticator/README.md
@@ -46,11 +46,12 @@ your running Keycloak.
 ```bash
 mvn -f keycloak/idp-error-authenticator/pom.xml clean package
 docker build -f keycloak/idp-error-authenticator/Dockerfile \
-  -t aula-keycloak:26.6.1 keycloak/idp-error-authenticator
+  -t aulaapp/aula-keycloak:26.5.5-aula keycloak/idp-error-authenticator
+docker push aulaapp/aula-keycloak:26.5.5-aula
 ```
 
-Point your Keycloak service at `aula-keycloak:26.6.1` instead of
-`quay.io/keycloak/keycloak:26.6.1` and recreate the container. Config lives in the DB, so
+Point your Keycloak service at `aulaapp/aula-keycloak:26.5.5-aula` instead of
+`quay.io/keycloak/keycloak:latest` and recreate the container. Config lives in the DB, so
 nothing is lost.
 
 ### Option B — mount the jar

--- a/keycloak/idp-error-authenticator/README.md
+++ b/keycloak/idp-error-authenticator/README.md
@@ -46,11 +46,11 @@ your running Keycloak.
 ```bash
 mvn -f keycloak/idp-error-authenticator/pom.xml clean package
 docker build -f keycloak/idp-error-authenticator/Dockerfile \
-  -t aulaapp/aula-keycloak:26.5.5-aula keycloak/idp-error-authenticator
-docker push aulaapp/aula-keycloak:26.5.5-aula
+  -t aulaapp/aula-keycloak:26.6.1-aula keycloak/idp-error-authenticator
+docker push aulaapp/aula-keycloak:26.6.1-aula
 ```
 
-Point your Keycloak service at `aulaapp/aula-keycloak:26.5.5-aula` instead of
+Point your Keycloak service at `aulaapp/aula-keycloak:26.6.1-aula` instead of
 `quay.io/keycloak/keycloak:latest` and recreate the container. Config lives in the DB, so
 nothing is lost.
 

--- a/keycloak/idp-error-authenticator/pom.xml
+++ b/keycloak/idp-error-authenticator/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
         <!-- Must match the Keycloak version you deploy to. -->
-        <keycloak.version>26.5.5</keycloak.version>
+        <keycloak.version>26.6.1</keycloak.version>
     </properties>
 
     <dependencies>

--- a/keycloak/idp-error-authenticator/pom.xml
+++ b/keycloak/idp-error-authenticator/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
         <!-- Must match the Keycloak version you deploy to. -->
-        <keycloak.version>26.6.1</keycloak.version>
+        <keycloak.version>26.5.5</keycloak.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Context <!-- ie. explanations, background, documentation -->

1. issue: export/import of keycloak config is supported by keycloak-config-cli up to version 26.5.5 at the moment, and we're not using any newer functionalities, so i reverted this back
2. Edgar pointed out we really need https://github.com/keycloak/keycloak/issues/47955 from 26.6.1, so i let it be (although the issue seems to be only introduced in 26.6.0, we haven't tested 26.5.5)
3. as a circumvention, there are both `aulaapp/aula-keycloak:25.5.5-aula` and `aulaapp/aula-keycloak:25.6.1-aula` built images.. we can use former to load the config and the latter for runtime.. this is anyways a temporary solution for migration..
4. nitpick: also build with "health enabled" config


## Checklist

- [x] Tested manually <!-- you can strikethrough this option in case you haven't tested manually -->
- [ ] GitHub issue linked <!-- Use the "Development" field of the Issue, or add a link if it's outside this Repo -->
- [ ] Changelist updated
- [x] Backward and forward compatible with [aula-frontend/releases](https://github.com/aula-app/aula-frontend/releases) <!-- If not, please describe in detail and include other PR links -->
- [x] Independent of the other BE version (v1 <-> v2) <!-- If it isn't, please describe how to deploy them together without downtime -->
- [ ] Must be deployed ASAP (HOTFIX)
- [ ] Needs update of [docs.aula.de](https://docs.aula.de/) ([repo](https://github.com/leonard-haas/docs_aula)) <!-- If it does, please ping Leonard OR include link to the change in the docs repo -->
